### PR TITLE
sets correct Docker image name

### DIFF
--- a/k8s/chart/deployment.yaml
+++ b/k8s/chart/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
         - name: dino-park-front-end
-          image: mozillaparsys/dino-park-front-end:latest
+          image: mozillaparsys/dino-park-frontend:latest
           imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80


### PR DESCRIPTION
This runs perfectly in Kubernetes (once the image name is fixed). Nice work!