### PR TITLE
Add search front-end

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -48,12 +48,7 @@ export default {
     font-family: "Open Sans", sans-serif;
     scroll-behavior: smooth;
     margin: 0;
-    padding-top: 4em;
-  }
-  @media(min-width:50em) {
-    body {
-      padding-top: 6em; /* allow for top bar */
-    }
+    padding-top: 4.5em;  /* allow for top bar */
   }
 
   h1,

--- a/src/App.vue
+++ b/src/App.vue
@@ -111,6 +111,7 @@ export default {
 
   .container {
     padding: 0 1em;
+    width: 100%;
   }
   @media(min-width:50em) {
     .container {

--- a/src/App.vue
+++ b/src/App.vue
@@ -37,6 +37,8 @@ export default {
   --layerModal: 3;
 
   --shadowCard: 0 .25em .25em 0 rgba(210, 210, 210, .5);
+
+  --imageRadius: .25em;
   }
 
   * {

--- a/src/assets/images/search.svg
+++ b/src/assets/images/search.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="11" cy="11" r="8" />
+  <line x1="21" y1="21" x2="16.65" y2="16.65" />
+</svg>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -1,0 +1,76 @@
+<template>
+  <form class="search-form" :action="'/search/' + searchQuery" @submit="preventEmptySubmit">
+    <fieldset>
+      <legend class="visually-hidden">Search</legend>
+      <div class="search-form__fields">
+        <button type="submit" class="search-form__submit">
+          <img src="@/assets/images/search.svg" alt="" role="presentation" aria-hidden="true" width="20" />
+          <span class="visually-hidden">Search</span>
+        </button>
+        <label for="search-query" class="visually-hidden">Search term</label>
+        <input type="search" id="search-query" v-model="searchQuery" class="search-form__input" ref="searchQueryField">
+      </div>
+    </fieldset>
+  </form>
+</template>
+
+<script>
+export default {
+  name: 'SearchForm',
+  methods: {
+    preventEmptySubmit(event) {
+      if(!this.$refs.searchQueryField.value) {
+        event.preventDefault();
+        this.$refs.searchQueryField.focus();
+        console.log('empty11! ');
+      }
+    },
+  },
+  data() {
+    return {
+      searchQuery: null,
+    };
+  },  
+};
+</script>
+
+<style>
+.search-form {
+  margin-right: auto;
+  width: 100%;
+  max-width: 25em;
+}
+  .search-form fieldset {
+    border: 0;
+    padding: 0;
+  }
+  .search-form__fields {
+    display: flex;
+    flex-direction: row;
+  }
+     .search-form__fields input,
+     .search-form__fields button {
+       font-size: inherit;
+       border: 1px solid var(--gray-30);
+       padding: .5em;
+       background-color: var(--white);
+     }
+     .search-form__fields input:focus,
+     .search-form__fields button:focus {
+       outline: none;
+       outline: 0;
+       border-color: var(--blue-60);
+     }
+     .search-form__input {
+       width: 100%;
+     }
+    .search-form__submit {
+       border: 0;
+       appearance: none;
+       width: 2.5em;
+       margin-right: -1px;
+    }
+      .search-form__submit img {
+        vertical-align: middle;
+      }
+</style>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -1,5 +1,5 @@
 <template>
-  <form class="search-form" :action="'/search/' + searchQuery" @submit="preventEmptySubmit">
+  <form :class="'search-form' + ( modifier ? ' ' + modifier : '')" :action="'/search/' + searchQuery" @submit="preventEmptySubmit">
     <fieldset>
       <legend class="visually-hidden">Search</legend>
       <div class="search-form__fields">
@@ -17,14 +17,19 @@
 <script>
 export default {
   name: 'SearchForm',
+  props: {
+    modifier: String,
+  },
   methods: {
     preventEmptySubmit(event) {
       if(!this.$refs.searchQueryField.value) {
         event.preventDefault();
         this.$refs.searchQueryField.focus();
-        console.log('empty11! ');
       }
     },
+  },
+  mounted() {
+    this.$refs.searchQueryField.focus();
   },
   data() {
     return {
@@ -73,4 +78,9 @@ export default {
       .search-form__submit img {
         vertical-align: middle;
       }
+
+.search-form--small {
+  padding: 1em;
+  max-width: none;
+}
 </style>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -60,14 +60,11 @@ export default {
        padding: .5em;
        background-color: var(--white);
      }
-     .search-form__fields input:focus,
-     .search-form__fields button:focus {
-       outline: none;
-       outline: 0;
-       border-color: var(--blue-60);
-     }
      .search-form__input {
        width: 100%;
+       -webkit-appearance: none;
+       appearance: none;
+       border-radius: 0;
      }
     .search-form__submit {
        border: 0;
@@ -82,5 +79,7 @@ export default {
 .search-form--small {
   padding: 1em;
   max-width: none;
+  background: var(--white);
+  margin-bottom: 1em;
 }
 </style>

--- a/src/components/SearchForm.vue
+++ b/src/components/SearchForm.vue
@@ -22,7 +22,7 @@ export default {
   },
   methods: {
     preventEmptySubmit(event) {
-      if(!this.$refs.searchQueryField.value) {
+      if (!this.$refs.searchQueryField.value) {
         event.preventDefault();
         this.$refs.searchQueryField.focus();
       }
@@ -35,7 +35,7 @@ export default {
     return {
       searchQuery: null,
     };
-  },  
+  },
 };
 </script>
 

--- a/src/components/SearchResult.vue
+++ b/src/components/SearchResult.vue
@@ -1,0 +1,40 @@
+<template>
+  <li class="search-result">
+    <div>
+      <div class="search-result__name">{{ first_name.value }} {{ last_name.value }}</div>
+      <div class="search-result__title">{{ fun_title.value }}</div>
+    </div>
+    <a :href="'/org/' + user_id.value" class="search-result__link">
+      <img src="@/assets/images/org-chart.svg" width="30" alt="" aria-hidden="true" role="presentation" />
+      <span class="visually-hidden">View {{ user_id.value }} in org chart</span>
+    </a>
+  </li>
+</template>
+
+<script>
+export default {
+  name: 'SearchResult',
+  props: {
+    first_name: Object,
+    last_name: Object,
+    fun_title: Object,
+    user_id: Object,
+    picture: Object,
+  },
+};
+</script>
+
+<style>
+  .search-result {
+    background: var(--white);
+    padding: 1em;
+    box-shadow: var(--shadowCard);
+    margin-bottom: 1em;
+    display: flex;
+    width: 100%;
+    align-items: center;
+  }
+    .search-result__link {
+      margin-left: auto;
+    }
+</style>

--- a/src/components/SearchResult.vue
+++ b/src/components/SearchResult.vue
@@ -1,5 +1,6 @@
 <template>
   <li class="search-result">
+    <img v-if="picture.value" :src="picture.value" alt="" class="search-result__image">
     <div>
       <div class="search-result__name">{{ first_name.value }} {{ last_name.value }}</div>
       <div class="search-result__title">{{ fun_title.value }}</div>
@@ -34,6 +35,18 @@ export default {
     width: 100%;
     align-items: center;
   }
+    .search-result__image {
+      width: 3em;
+      height: 3em;
+      margin-right: 1em;
+      border-radius: var(--imageRadius);
+    }
+    .search-result__name {
+      font-weight: 700;
+    }
+    .search-result__title {
+      color: var(--gray-50);
+    }
     .search-result__link {
       margin-left: auto;
     }

--- a/src/components/SearchResultList.vue
+++ b/src/components/SearchResultList.vue
@@ -13,7 +13,7 @@ export default {
     results: Object,
   },
   components: {
-    SearchResult
+    SearchResult,
   },
 };
 </script>
@@ -21,9 +21,14 @@ export default {
 <style>
   .search-result-list {
     padding: 0;
-    margin: 0;
+    margin: 0 -1em;
   }
-  .search-result-list li {
-    list-style: none;
+  @media(min-width:50em) {
+    .search-result-list {
+      margin: 0;
+    }
   }
+    .search-result-list li {
+      list-style: none;
+    }
 </style>

--- a/src/components/SearchResultList.vue
+++ b/src/components/SearchResultList.vue
@@ -1,0 +1,29 @@
+<template>
+  <ul class="search-result-list">
+    <SearchResult v-for="(result, index) in results.dinos" :key="index" v-bind="result"></SearchResult>
+  </ul>
+</template>
+
+<script>
+import SearchResult from '@/components/SearchResult.vue';
+
+export default {
+  name: 'SearchResultList',
+  props: {
+    results: Object,
+  },
+  components: {
+    SearchResult
+  },
+};
+</script>
+
+<style>
+  .search-result-list {
+    padding: 0;
+    margin: 0;
+  }
+  .search-result-list li {
+    list-style: none;
+  }
+</style>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -3,9 +3,12 @@
     <div class="top-bar__bar">
       <router-link :to="{ name: 'Home' }" class="top-bar__link top-bar__link--logo"><img src="@/assets/images/mozilla.svg" alt="Mozilla logo" width="90" /></router-link>
       <SearchForm class="hide-mobile"></SearchForm>
-      <button class="hide-desktop" @click="toggleMobileSearch">
-        <template v-if="mobileSearchOpen">Hide search</template>
-        <template v-else>Show search</template>
+      <button class="hide-desktop top-bar__search" @click="toggleMobileSearch">
+        <img src="@/assets/images/search.svg" alt="" role="presentation" aria-hidden="true" width="20" />
+        <span class="visually-hidden">
+          <template v-if="mobileSearchOpen">Hide search</template>
+          <template v-else>Show search</template>
+        </span>
       </button>
       <router-link :to="{ name: 'Orgchart' }" class="top-bar__link"><img src="@/assets/images/org-chart.svg" alt="Org chart" width="20" /></router-link>
       <ShowMore buttonText="Open user menu" alternateButtonText="Close user menu" buttonClass="top-bar__user-menu-toggle" :expanded="false" v-on:close-user-menu="closeUserMenu()" ref="showMoreEl">
@@ -62,7 +65,11 @@ export default {
     top: 0;
     padding: .25em;
     z-index: var(--layerTopBar);
-  }
+  } 
+    .top-bar__search {
+      border: 0;
+      background-color: transparent;
+    }
     .top-bar__link {
       padding: 1.25em;
       text-transform: uppercase;

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -3,14 +3,14 @@
     <div class="top-bar__bar">
       <router-link :to="{ name: 'Home' }" class="top-bar__link top-bar__link--logo"><img src="@/assets/images/mozilla.svg" alt="Mozilla logo" width="90" /></router-link>
       <SearchForm class="hide-mobile"></SearchForm>
-      <button class="hide-desktop top-bar__search" @click="toggleMobileSearch">
+      <button class="hide-desktop top-bar__search-toggle" @click="toggleMobileSearch" aria-controls="mobile-search" :aria-expanded="mobileSearchOpen ? 'true' : 'false'">
         <img src="@/assets/images/search.svg" alt="" role="presentation" aria-hidden="true" width="20" />
         <span class="visually-hidden">
           <template v-if="mobileSearchOpen">Hide search</template>
           <template v-else>Show search</template>
         </span>
       </button>
-      <router-link :to="{ name: 'Orgchart' }" class="top-bar__link"><img src="@/assets/images/org-chart.svg" alt="Org chart" width="20" /></router-link>
+      <router-link :to="{ name: 'Orgchart' }" class="top-bar__link" exact-active-class="top-bar__link--current"><img src="@/assets/images/org-chart.svg" alt="Org chart" width="20" /></router-link>
       <ShowMore buttonText="Open user menu" alternateButtonText="Close user menu" buttonClass="top-bar__user-menu-toggle" :expanded="false" v-on:close-user-menu="closeUserMenu()" ref="showMoreEl">
         <template slot="overflow">
           <UserMenu></UserMenu>
@@ -20,7 +20,7 @@
         </template>
       </ShowMore>
     </div>
-    <SearchForm modifier="search-form--small hide-desktop" v-if="mobileSearchOpen"></SearchForm>
+    <SearchForm modifier="search-form--small hide-desktop" v-if="mobileSearchOpen" id="mobile-search"></SearchForm>
   </header>
 </template>
 
@@ -66,9 +66,14 @@ export default {
     padding: .25em;
     z-index: var(--layerTopBar);
   }
-    .top-bar__search {
+    .top-bar__search-toggle {
       border: 0;
       background-color: transparent;
+      padding: 1em;
+      line-height: 0;
+    }
+    .top-bar__search-toggle[aria-expanded="true"] {
+      background-color: var(--gray-20);
     }
     .top-bar__link {
       padding: 1.25em;
@@ -80,6 +85,18 @@ export default {
     }
     .top-bar__link img {
       vertical-align: middle;
+    }
+    .top-bar__link--current  {
+      position: relative;
+    }
+    .top-bar__link--current::after {
+      content: '';
+      height: 2px;
+      background: black;
+      width: 100%;
+      position: absolute;
+      bottom: -.5em;
+      left: 0;
     }
     .top-bar__link--logo {
       margin-right: auto;

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -1,6 +1,7 @@
 <template>
   <header class="top-bar">
     <router-link :to="{ name: 'Home' }" class="top-bar__link top-bar__link--logo"><img src="@/assets/images/mozilla.svg" alt="Mozilla logo" width="90" /></router-link>
+    <SearchForm></SearchForm>
     <router-link :to="{ name: 'Orgchart' }" class="top-bar__link"><img src="@/assets/images/org-chart.svg" alt="Org chart" width="20" /></router-link>
     <ShowMore buttonText="Open user menu" alternateButtonText="Close user menu" buttonClass="top-bar__user-menu-toggle" :expanded="false" v-on:close-user-menu="closeUserMenu()" ref="showMoreEl">
       <template slot="overflow">
@@ -14,12 +15,14 @@
 </template>
 
 <script>
+import SearchForm from '@/components/SearchForm.vue';
 import ShowMore from '@/components/functional/ShowMore.vue';
 import UserMenu from '@/components/UserMenu.vue';
 
 export default {
   name: 'TopBar',
   components: {
+    SearchForm,
     ShowMore,
     UserMenu,
   },
@@ -27,6 +30,11 @@ export default {
     closeUserMenu() {
       this.$refs.showMoreEl.expanded = false;
     },
+  },
+  data() {
+    return {
+      searchQuery: '',
+    };
   },
 };
 </script>

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -42,7 +42,7 @@ export default {
     },
     toggleMobileSearch() {
       this.mobileSearchOpen ? this.mobileSearchOpen = false : this.mobileSearchOpen = true;
-    }
+    },
   },
   data() {
     return {
@@ -65,7 +65,7 @@ export default {
     top: 0;
     padding: .25em;
     z-index: var(--layerTopBar);
-  } 
+  }
     .top-bar__search {
       border: 0;
       background-color: transparent;

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -1,16 +1,23 @@
 <template>
   <header class="top-bar">
-    <router-link :to="{ name: 'Home' }" class="top-bar__link top-bar__link--logo"><img src="@/assets/images/mozilla.svg" alt="Mozilla logo" width="90" /></router-link>
-    <SearchForm></SearchForm>
-    <router-link :to="{ name: 'Orgchart' }" class="top-bar__link"><img src="@/assets/images/org-chart.svg" alt="Org chart" width="20" /></router-link>
-    <ShowMore buttonText="Open user menu" alternateButtonText="Close user menu" buttonClass="top-bar__user-menu-toggle" :expanded="false" v-on:close-user-menu="closeUserMenu()" ref="showMoreEl">
-      <template slot="overflow">
-        <UserMenu></UserMenu>
-      </template>
-      <template slot="button-content">
-        <img src="@/assets/images/user-demo.png" alt="Avatar" width="40" />
-      </template>
-    </ShowMore>
+    <div class="top-bar__bar">
+      <router-link :to="{ name: 'Home' }" class="top-bar__link top-bar__link--logo"><img src="@/assets/images/mozilla.svg" alt="Mozilla logo" width="90" /></router-link>
+      <SearchForm class="hide-mobile"></SearchForm>
+      <button class="hide-desktop" @click="toggleMobileSearch">
+        <template v-if="mobileSearchOpen">Hide search</template>
+        <template v-else>Show search</template>
+      </button>
+      <router-link :to="{ name: 'Orgchart' }" class="top-bar__link"><img src="@/assets/images/org-chart.svg" alt="Org chart" width="20" /></router-link>
+      <ShowMore buttonText="Open user menu" alternateButtonText="Close user menu" buttonClass="top-bar__user-menu-toggle" :expanded="false" v-on:close-user-menu="closeUserMenu()" ref="showMoreEl">
+        <template slot="overflow">
+          <UserMenu></UserMenu>
+        </template>
+        <template slot="button-content">
+          <img src="@/assets/images/user-demo.png" alt="Avatar" width="40" />
+        </template>
+      </ShowMore>
+    </div>
+    <SearchForm modifier="search-form--small hide-desktop" v-if="mobileSearchOpen"></SearchForm>
   </header>
 </template>
 
@@ -30,17 +37,21 @@ export default {
     closeUserMenu() {
       this.$refs.showMoreEl.expanded = false;
     },
+    toggleMobileSearch() {
+      this.mobileSearchOpen ? this.mobileSearchOpen = false : this.mobileSearchOpen = true;
+    }
   },
   data() {
     return {
       searchQuery: '',
+      mobileSearchOpen: false,
     };
   },
 };
 </script>
 
 <style>
-  .top-bar {
+  .top-bar__bar {
     background-color: var(--white);
     border-bottom: 1px solid var(--gray-30);
     display: flex;

--- a/src/router.js
+++ b/src/router.js
@@ -3,6 +3,7 @@ import Router from 'vue-router';
 import PageHome from './views/PageHome.vue';
 import PageProfile from './views/PageProfile.vue';
 import PageOrgchart from './views/PageOrgchart.vue';
+import PageSearchResult from './views/PageSearchResult.vue';
 
 Vue.use(Router);
 
@@ -25,6 +26,12 @@ const router = new Router({
       path: '/org/:userId?',
       name: 'Orgchart',
       component: PageOrgchart,
+      props: true,
+    },
+    {
+      path: '/search/:query?',
+      name: 'Search results',
+      component: PageSearchResult,
       props: true,
     },
   ],

--- a/src/views/PageOrgchart.vue
+++ b/src/views/PageOrgchart.vue
@@ -5,7 +5,7 @@
       <Error v-else-if="error">
         <h2>{{ error.message }}</h2>
         <pre>{{ error }}</pre>
-        <p>An error occured while trying to go to load the Orgchart</p>
+        <p>An error occured while trying to go to load the org chart.</p>
       </Error>
       <OrgRoot v-else-if="tree" :roots="tree"></OrgRoot>
       <LoadingSpinner v-else></LoadingSpinner>

--- a/src/views/PageSearchResult.vue
+++ b/src/views/PageSearchResult.vue
@@ -7,9 +7,12 @@
       <pre>{{ error }}</pre>
       <p>An error occured while trying to go to load the search results</p>
     </Error>
-    <template v-else-if="results">
+    <template v-else-if="this.$route.params.query && results">
       <p>{{ results.total }} results for <strong>{{ this.$route.params.query }}</strong></p>
       <SearchResultList :results="results"></SearchResultList>
+    </template>
+    <template v-else>
+      <p>You have not searched.</p>
     </template>
     <LoadingSpinner v-else></LoadingSpinner>
   </main>

--- a/src/views/PageSearchResult.vue
+++ b/src/views/PageSearchResult.vue
@@ -1,0 +1,59 @@
+<template>
+  <main class="container">
+    <h1>Search results</h1>
+    <LoadingSpinner v-if="loading"></LoadingSpinner>
+    <Error v-else-if="error">
+      <h2>{{ error.message }}</h2>
+      <pre>{{ error }}</pre>
+      <p>An error occured while trying to go to load the search results</p>
+    </Error>
+    <template v-else-if="results">
+      <p>{{ results.total }} results</p>
+      <SearchResultList :results="results"></SearchResultList>
+    </template>
+    <LoadingSpinner v-else></LoadingSpinner>
+  </main>
+</template>
+
+<script>
+import Error from '@/components/Error.vue';
+import LoadingSpinner from '@/components/LoadingSpinner.vue';
+import SearchResultList from '@/components/SearchResultList.vue';
+
+export default {
+  name: 'PageSearchResult',
+  components: {
+    Error,
+    LoadingSpinner,
+    SearchResultList,
+  },
+  data() {
+    return {
+      loading: false,
+      post: null,
+      error: null,
+    };
+  },
+  created() {
+    this.fetchData();
+  },
+  methods: {
+    async fetchData() {
+      this.error = null;
+      this.post = null;
+      this.loading = true;
+      try {
+        const data = await fetch('http://localhost:8889/search/simple/public/' + this.$route.params.query);
+        const results = await data.json();
+        this.results = results;
+      } catch (e) {
+        this.error = e;
+      }
+      this.loading = false;
+    },
+  },
+};
+</script>
+
+<style>
+</style>

--- a/src/views/PageSearchResult.vue
+++ b/src/views/PageSearchResult.vue
@@ -8,7 +8,7 @@
       <p>An error occured while trying to go to load the search results</p>
     </Error>
     <template v-else-if="results">
-      <p>{{ results.total }} results</p>
+      <p>{{ results.total }} results for <strong>{{ this.$route.params.query }}</strong></p>
       <SearchResultList :results="results"></SearchResultList>
     </template>
     <LoadingSpinner v-else></LoadingSpinner>

--- a/src/views/PageSearchResult.vue
+++ b/src/views/PageSearchResult.vue
@@ -1,7 +1,10 @@
 <template>
   <main class="container">
     <h1>Search results</h1>
-    <LoadingSpinner v-if="loading"></LoadingSpinner>
+    <template v-if="!this.$route.params.query">
+      <p>You have not searched.</p>
+    </template>
+    <LoadingSpinner v-else-if="loading"></LoadingSpinner>
     <Error v-else-if="error">
       <h2>{{ error.message }}</h2>
       <pre>{{ error }}</pre>
@@ -11,10 +14,6 @@
       <p>{{ results.total }} results for <strong>{{ this.$route.params.query }}</strong></p>
       <SearchResultList :results="results"></SearchResultList>
     </template>
-    <template v-else>
-      <p>You have not searched.</p>
-    </template>
-    <LoadingSpinner v-else></LoadingSpinner>
   </main>
 </template>
 

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,6 @@
 const GRAPHQL_URL = process.env.DP_K8S ? 'http://dinopark.mozilla.community:80' : 'http://localhost:5000';
 const ORGCHART_URL = process.env.DP_K8S ? 'http://dinopark.mozilla.community:80' : 'http://localhost:8888';
+const SEARCH_URL = process.env.DP_K8S ? 'http://dinopark.mozilla.community:80' : 'http://localhost:8889';
 const BASE_URL = process.env.DP_BASE_URL || '/';
 
 module.exports = {
@@ -28,6 +29,10 @@ module.exports = {
       },
       '/orgchart': {
         target: ORGCHART_URL,
+        changeOrigin: true,
+      },
+      '/search': {
+        target: SEARCH_URL,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
Some implementation notes: 

* `.hide-mobile` / `.hide-desktop` hide from mobile/desktop (fully hide, with `display:none`); our page now contains two search forms (one with `.hide-mobile`, one with `.hide-desktop`), so that users only ever get one. Because there are two, they are flexible and need little hacking (one is in the header, one after the header, etc)
* the URL we `fetch` search data from is hardcoded. @fiji-flo can you help me do what you've done with the org chart URL