### PR TITLE
adding buildspec for CodeBuild

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,0 +1,34 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - echo "Installing dependencies"
+      - apt update && apt install apt-transport-https
+      - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+      - echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+      - apt update && apt install -y curl kubectl python3-pip
+      - pip3 install awscli
+      - curl -O https://storage.googleapis.com/kubernetes-helm/helm-v2.11.0-linux-amd64.tar.gz
+      - tar zxvf helm-v2.11.0-linux-amd64.tar.gz
+      - cp linux-amd64/helm /usr/local/bin/
+      - curl -O https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-07-26/bin/linux/amd64/aws-iam-authenticator
+      - chmod +x aws-iam-authenticator
+      - cp aws-iam-authenticator /usr/local/bin/
+      - echo "Configuring kubectl"
+      - aws eks update-kubeconfig --name $CLUSTER_NAME
+      - echo "Building and pushing to ECR"
+      - COMMIT_SHA=$(git rev-parse HEAD)
+      - docker build -t $PROJECT_NAME:$COMMIT_SHA .
+      - aws ecr get-login --region us-west-2 --no-include-email | bash
+      - docker tag $PROJECT_NAME:$COMMIT_SHA 320464205386.dkr.ecr.us-west-2.amazonaws.com/$PROJECT_NAME:$COMMIT_SHA
+      - docker push 320464205386.dkr.ecr.us-west-2.amazonaws.com/$PROJECT_NAME:$COMMIT_SHA
+  post_build:
+    commands:
+      - echo "Finding appropriate deployment environment"
+      - curl -O iam-codebuild-assets.s3.amazonaws.com/dino-park-deploy.sh
+      - chmod +x dino-park-deploy.sh
+      - DEPLOY_ENV=$(./dino-park-deploy.sh)
+      - echo "Environment is " $DEPLOY_ENV
+      - helm template -f k8s/values.yaml -f k8s/values/staging.yaml --set docker_registry=320464205386.dkr.ecr.us-west-2.amazonaws.com,namespace=mozillians-dinopark-stage,rev=$COMMIT_SHA k8s/ | kubectl --token $DEPLOY_TOKEN apply -f -
+


### PR DESCRIPTION
This first PR will move the buildspec out of the eks-deployment Terraform and into each project repo. In this specific project, I am defaulting to helm template rendering with staging.yaml and deploying to the mozillians-dinopark-stage namespace.