### PR TITLE
Add DinoType (Staff/Contributor)

### DIFF
--- a/src/components/DinoType.vue
+++ b/src/components/DinoType.vue
@@ -1,0 +1,26 @@
+<template>
+  <span class="dino-type">
+    <template v-if="size === 'small'">
+      <span aria-hidden="true">{{ type[0] }}</span>
+      <span class="visually-hidden">{{ type }}</span>
+    </template>
+    <template v-else>{{ type }}</template>
+  </span>
+</template>
+
+<script>
+export default {
+  name: 'DinoType',
+  props: {
+    type: String,
+    size: String,
+  },
+};
+</script>
+
+<style>
+.dino-type {
+  background-color: var(--black);
+  color: var(--white);
+}
+</style>

--- a/src/components/OrgNode.vue
+++ b/src/components/OrgNode.vue
@@ -1,7 +1,7 @@
 <template>
   <li :id="data.user_id" :class="'org-node' + ( data.user_id === this.$route.params.userId ? ' org-node--current' : '')">
     <router-link :to="{ name: 'Orgchart', params: { userId: data.user_id } }" :id="`org-node-${prefix}`">
-      <UserPicture :picture="data.picture" :username="data.user_id" :size="40"></UserPicture>
+      <UserPicture :picture="data.picture" :username="data.user_id" :size="40" dinoType="Staff"></UserPicture>
       <span class="org-node__name">{{ data.first_name }} {{ data.last_name }}</span>
       <span class="org-node__title">{{ data.title }}</span>
     </router-link>

--- a/src/components/OrgNode.vue
+++ b/src/components/OrgNode.vue
@@ -1,7 +1,7 @@
 <template>
   <li :id="data.user_id" :class="'org-node' + ( data.user_id === this.$route.params.userId ? ' org-node--current' : '')">
     <router-link :to="{ name: 'Orgchart', params: { userId: data.user_id } }" :id="`org-node-${prefix}`">
-      <UserPicture :picture="data.picture" :username="data.user_id" cls="org-node__photo" size="40"></UserPicture>
+      <UserPicture :picture="data.picture" :username="data.user_id" :size="40"></UserPicture>
       <span class="org-node__name">{{ data.first_name }} {{ data.last_name }}</span>
       <span class="org-node__title">{{ data.title }}</span>
     </router-link>
@@ -89,7 +89,7 @@ export default {
   text-decoration: none;
   color: inherit;
   padding-left: 2em;
-  padding-left: calc((var(--nodeLevel) + 2) * .95em);
+  padding-left: calc((var(--nodeLevel) + 2) * .85em);
   border-left: 5px solid transparent;
 }
 .org-node--current > a,
@@ -140,12 +140,8 @@ export default {
   position: absolute;
   left: -9999em;
 }
-.org-node__photo,
-.show-more .org-node__photo {
-  width: 2.25em;
-  border-radius: var(--imageRadius);
+.org-node .user-picture {
   float: left;
-  margin-top: 0.125em;
-  margin-right: 1em;
+  margin-right: .75em;
 }
 </style>

--- a/src/components/Person.vue
+++ b/src/components/Person.vue
@@ -1,7 +1,10 @@
 <template>
   <div :class="'person' + ( modifier ? ' ' + modifier : '')">
-    <router-link :to="{ name: 'Profile', params: { userId: userId.value } }">
+    <router-link :to="{ name: 'Profile', params: { userId: userId.value } }" aria-hidden="true" role="presentation">
+      <div class="person__photo">
       <UserPicture :picture="picture.value" :username="userId.value" cls="person__photo" :title="firstName.value + ' ' + lastName.value" size="100"></UserPicture>
+        <DinoType type="Staff" size="small" />
+      </div>
     </router-link>
     <div class="person__name-title">
       <div class="person__name">
@@ -22,6 +25,7 @@
 </template>
 
 <script>
+import DinoType from '@/components/DinoType.vue';
 import UserPicture from '@/components/UserPicture.vue';
 
 export default {
@@ -37,6 +41,7 @@ export default {
     picture: Object,
   },
   components: {
+    DinoType,
     UserPicture,
   },
 };
@@ -89,9 +94,11 @@ export default {
       top: 1em;
       left: -1em;
       width: 2.25em;
-      max-height: 2.25em;
-      border-radius: var(--imageRadius);
+      height: 2.25em;
     }
+      .person__photo img {
+        border-radius: var(--imageRadius);
+      }
     .person__location-label {
       color: var(--gray-50);
     }

--- a/src/components/Person.vue
+++ b/src/components/Person.vue
@@ -1,10 +1,7 @@
 <template>
   <div :class="'person' + ( modifier ? ' ' + modifier : '')">
     <router-link :to="{ name: 'Profile', params: { userId: userId.value } }" aria-hidden="true" role="presentation">
-      <div class="person__photo">
-      <UserPicture :picture="picture.value" :username="userId.value" cls="person__photo" :title="firstName.value + ' ' + lastName.value" size="100"></UserPicture>
-        <DinoType type="Staff" size="small" />
-      </div>
+      <UserPicture :picture="picture.value" :username="userId.value" :title="firstName.value + ' ' + lastName.value" :size="40" dinoType="Staff" />
     </router-link>
     <div class="person__name-title">
       <div class="person__name">
@@ -89,16 +86,6 @@ export default {
     .person__preferred-title {
       color: var(--gray-50);
     }
-    .person__photo {
-      position: absolute;
-      top: 1em;
-      left: -1em;
-      width: 2.25em;
-      height: 2.25em;
-    }
-      .person__photo img {
-        border-radius: var(--imageRadius);
-      }
     .person__location-label {
       color: var(--gray-50);
     }
@@ -139,8 +126,7 @@ export default {
     background-color: transparent;
     display: flex;
   }
-    .person--borderless .person__photo {
-      position: static;
+    .person--borderless .user-picture {
       align-self: center;
       margin-right: 1em;
     }

--- a/src/components/Person.vue
+++ b/src/components/Person.vue
@@ -1,19 +1,17 @@
 <template>
   <div :class="'person' + ( modifier ? ' ' + modifier : '')">
-    <router-link :to="{ name: 'Profile', params: { userId: userId.value } }" aria-hidden="true" role="presentation">
-      <UserPicture :picture="picture.value" :username="userId.value" :title="firstName.value + ' ' + lastName.value" :size="40" dinoType="Staff" />
+    <UserPicture :picture="picture.value" :username="userId.value" :title="firstName.value + ' ' + lastName.value" :size="40" dinoType="Staff" />
+    <router-link :to="{ name: 'Profile', params: { userId: userId.value } }">
+      <div class="person__name-title">
+        <div class="person__name">
+            {{ firstName.value }} {{ lastName.value }}
+        </div>
+        <div class="person__preferred-title">
+          <template v-if="funTitle">{{ funTitle.value }}</template>
+          <template v-else-if="businessTitle">{{ "businessTitle.value" }}</template>
+        </div>
+      </div>
     </router-link>
-    <div class="person__name-title">
-      <div class="person__name">
-        <router-link :to="{ name: 'Profile', params: { userId: userId.value } }">
-          {{ firstName.value }} {{ lastName.value }}
-        </router-link>
-      </div>
-      <div class="person__preferred-title">
-        <template v-if="funTitle">{{ funTitle.value }}</template>
-        <template v-else-if="businessTitle">{{ "businessTitle.value" }}</template>
-      </div>
-    </div>
     <div v-if="officeLocation" class="person__location">
       <div v-if="modifier === 'person--wide'" class="person__location-label">Location</div>
       {{ officeLocation.value }}
@@ -61,11 +59,11 @@ export default {
     .person__name {
       font-weight: 700;
     }
-      .person__name a {
+      .person a {
         color: inherit;
         text-decoration: none;
       }
-      .person__name a::after {
+      .person a::after {
         content: '';
         width: 1em;
         height: 1em;
@@ -77,11 +75,11 @@ export default {
         height: 100%;
         border: 1px solid transparent;
       }
-      .person__name a:focus {
+      .person a:focus {
         outline: none;
       }
-      .person__name a:focus::after {
-        border: 1px solid var(--blue-60);
+      .person a:focus::after {
+        outline: 1px solid var(--blue-60);
       }
     .person__preferred-title {
       color: var(--gray-50);
@@ -134,13 +132,19 @@ export default {
     display: inline-block;
     vertical-align: top;
     margin-bottom: .5em;
+    margin-right: 1em;
   }
     .person--avatar-only + .person--avatar-only {
       margin-top: 0;
     }
     .person--avatar-only .person__name-title {
       position: absolute;
-      left: -9999em;
-      top: -9999em;
+      width: 1px;
+      height: 1px;
+      clip: rect(1px, 1px, 1px, 1px);
+      overflow: hidden;
+    }
+    .person--avatar-only .user-picture {
+      margin-right: 0;
     }
 </style>

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -3,7 +3,7 @@
     <section class="profile__section profile__intro">
       <div class="profile__intro-photo">
         <div class="profile__headshot">
-          <UserPicture :picture="picture.value" :username="userId.value" size="230"></UserPicture>
+          <UserPicture :picture="picture.value" :username="userId.value" :size="230" dinoType="Staff"></UserPicture>
         </div>
         <div class="hide-mobile">
           <ContactMe></ContactMe>
@@ -336,7 +336,7 @@ export default {
     margin-left: 0;
   }
   .profile__intro-photo .profile__headshot {
-    margin: 0 auto 1em;
+    margin: 0 auto 2em;
   }
 }
 

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -336,7 +336,7 @@ export default {
     margin-left: 0;
   }
   .profile__intro-photo .profile__headshot {
-    margin: 0 auto 2em;
+    margin: 0 auto 3em;
   }
 }
 

--- a/src/components/ProfilePreview.vue
+++ b/src/components/ProfilePreview.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="profile-preview" ref="profilePreviewElement" tabindex="-1">
     <div class="profile-preview__image">
-      <UserPicture :picture="picture.value" :username="userId.value" size="100"></UserPicture>
+      <UserPicture :picture="picture.value" :username="userId.value" :size="100" dinoType="Staff" />
     </div>
     <ProfileName :firstName="firstName.value" :lastName="lastName.value" :pronouns="pronouns.value"></ProfileName>
     <ProfileTitle :businessTitle="businessTitle.value || null" :funTitle="funTitle.value"></ProfileTitle>
@@ -103,7 +103,9 @@ export default {
   },
   mounted() {
     this.lastActive = document.activeElement;
-    this.$refs.profilePreviewElement.focus();
+    if (this.$refs.profilePreviewElement) {
+      this.$refs.profilePreviewElement.focus();
+    }
   },
 };
 </script>

--- a/src/components/ReportingStructure.vue
+++ b/src/components/ReportingStructure.vue
@@ -9,9 +9,7 @@
             :userId="{ value: manager.userId }"
             :firstName="{ value: manager.firstName }"
             :lastName="{ value: manager.lastName }"
-            :title="{ value: manager.title }"
             :funTitle="{ value: manager.funTitle }"
-            :location="{ value: manager.location }"
           />
     </div>
     <div v-if="directs.length > 0" class="reporting-structure__manages">
@@ -24,9 +22,7 @@
             :userId="{ value: direct.userId }"
             :firstName="{ value: direct.firstName }"
             :lastName="{ value: direct.lastName }"
-            :title="{ value: direct.title }"
             :funTitle="{ value: direct.funTitle }"
-            :location="{ value: direct.location }"
             />
     </div>
   </div>

--- a/src/components/SearchResult.vue
+++ b/src/components/SearchResult.vue
@@ -1,12 +1,12 @@
 <template>
   <li class="search-result">
-    <UserPicture :picture="picture" :username="user_id" cls="search-result__image" size="40"></UserPicture>
+    <UserPicture :picture="picture" :username="user_id" cls="search-result__image" :size="40"></UserPicture>
     <router-link :to="{ name: 'Profile', params: { userId: user_id } }" class="search-result__profile-link">
       <div class="search-result__name">{{ first_name }} {{ last_name }}</div>
       <div class="search-result__title">{{ fun_title }}</div>
     </router-link>
     <router-link :to="{ name: 'OrgchartHighlight', params: { userId: user_id } }" class="search-result__orgchart-link">
-      <img src="@/assets/images/org-chart.svg" width="30" alt="" aria-hidden="true" role="presentation" />
+      <img src="@/assets/images/org-chart.svg" width="26" alt="" aria-hidden="true" role="presentation" />
       <span class="visually-hidden">View {{ user_id }} in org chart</span>
     </router-link>
   </li>

--- a/src/components/SearchResult.vue
+++ b/src/components/SearchResult.vue
@@ -1,6 +1,6 @@
 <template>
   <li class="search-result">
-    <UserPicture :picture="picture" :username="user_id" cls="search-result__image" :size="40"></UserPicture>
+    <UserPicture :picture="picture" :username="user_id" cls="search-result__image" :size="40" dinoType="Staff"></UserPicture>
     <router-link :to="{ name: 'Profile', params: { userId: user_id } }" class="search-result__profile-link">
       <div class="search-result__name">{{ first_name }} {{ last_name }}</div>
       <div class="search-result__title">{{ fun_title }}</div>
@@ -41,12 +41,8 @@ export default {
     align-items: center;
     position: relative;
   }
-    .search-result__image {
-      width: 3em;
-      height: 3em;
+    .search-result .user-picture {
       margin-right: 1em;
-      border-radius: var(--imageRadius);
-      position: relative;
       z-index: 1;
     }
     .search-result__profile-link {

--- a/src/components/TopBar.vue
+++ b/src/components/TopBar.vue
@@ -26,7 +26,7 @@
                 <UserMenu v-bind="data.profile"></UserMenu>
               </template>
               <template slot="button-content">
-                <UserPicture :picture="data.profile.picture.value" :username="data.profile.userId.value" size="40"></UserPicture>
+                <UserPicture :picture="null" :username="data.profile.userId.value" :size="40" dinoType="Staff"></UserPicture>
               </template>
             </ShowMore>
           </template>

--- a/src/components/UserMenu.vue
+++ b/src/components/UserMenu.vue
@@ -3,7 +3,7 @@
     <div class="user-menu__header">
       <button class="user-menu__close-avatar" type="button" @click="sendCloseEvent()">
         <span class="visually-hidden">Close user menu</span>
-        <UserPicture :picture="picture.value" :username="userId.value" size="40"></UserPicture>
+        <UserPicture :picture="picture.value" :username="userId.value" :size="40"></UserPicture>
       </button>
       <div class="user-menu__name">
         <span class="user-menu__header-name">{{ firstName.value }} {{ lastName.value }}</span>
@@ -149,11 +149,8 @@ export default {
         border: 1px dotted currentColor;
       }
       .user-menu__close-avatar {
-        margin-right: 1.5em;
+        margin-right: 1em;
       }
-        .user-menu__close-avatar img {
-          min-width: 2.75em;
-        }
       .user-menu__close-button {
         margin-left: auto;
       }

--- a/src/components/UserPicture.vue
+++ b/src/components/UserPicture.vue
@@ -1,9 +1,13 @@
 <template>
-  <img :class="cls" :src="src" alt="" :width="size" :title="title" role="presentation" aria-hidden="true">
+  <div :class="'user-picture' + ( modifier ? ' ' + modifier : '')" :style="`width: ${size}px; height: ${size}px;`">
+    <img :class="cls" :src="src" alt="" :width="size" :title="title" role="presentation" aria-hidden="true">
+    <DinoType v-if="dinoType" :type="dinoType" :size="dinoTypeSize" />
+  </div>
 </template>
 
 
 <script>
+import DinoType from '@/components/DinoType.vue';
 import Identicon from 'identicon.js';
 
 function hex(buffer) {
@@ -27,11 +31,15 @@ function sha256(str) {
 export default {
   name: 'UserPicture',
   props: {
-    size: String,
+    size: Number,
     picture: String,
     username: String,
     title: String,
     cls: String,
+    dinoType: String,
+  },
+  components: {
+    DinoType,
   },
   watch: {
     username() {
@@ -39,18 +47,73 @@ export default {
     },
   },
   data() {
+    this.decidePictureCategory(this.size);
     this.updateUserPicture();
-    return { src: this.picture };
+    return {
+      src: this.picture,
+    };
   },
   methods: {
     updateUserPicture() {
-      if (this.picture === null) {
+      if (this.picture === null || this.picture === '/beta/img/user-demo.png') {
         sha256(this.username).then((hash) => {
           const identicon = new Identicon(hash, { size: this.size, format: 'svg' });
           this.src = `data:image/svg+xml;base64,${identicon.toString()}`;
         });
       }
     },
+    decidePictureCategory(size) {
+      if (size <= 40) {
+        this.modifier = 'user-picture--small';
+        this.dinoTypeSize = 'small';
+        return;
+      }
+      if (size <= 100) {
+        this.modifier = 'user-picture--medium';
+        this.dinoTypeSize = 'medium';
+        return;
+      }
+      this.modifier = 'user-picture--large';
+      this.dinoTypeSize = 'large';
+    }
   },
 };
 </script>
+
+<style>
+.user-picture {
+  position: relative;
+}
+  .user-picture img {
+    border-radius: var(--imageRadius);
+  }
+  .user-picture .dino-type {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    line-height: 1;
+    padding: .25em;
+  }
+  .user-picture--small .dino-type {
+    font-size: .75em;
+    text-transform: uppercase;
+    letter-spacing: .1em;
+    border-radius: var(--imageRadius) 0;
+    padding: .25em;
+  }
+  .user-picture--medium .dino-type {
+    font-size: .75em;
+    letter-spacing: .05em;
+    padding: .3em .6em;
+    border-radius: var(--imageRadius) 0;
+  }
+  .user-picture--large .dino-type {
+    left: 50%;
+    right: auto;
+    bottom: -.5em;
+    transform: translate(-50%,25%);
+    font-size: .9em;
+    padding: .75em 2em;
+    border-radius: 2em;
+  }
+</style>

--- a/src/components/UserPicture.vue
+++ b/src/components/UserPicture.vue
@@ -55,7 +55,7 @@ export default {
   },
   methods: {
     updateUserPicture() {
-      if (this.picture === null || this.picture === '/beta/img/user-demo.png') {
+      if (this.picture === null) {
         sha256(this.username).then((hash) => {
           const identicon = new Identicon(hash, { size: this.size, format: 'svg' });
           this.src = `data:image/svg+xml;base64,${identicon.toString()}`;
@@ -75,7 +75,7 @@ export default {
       }
       this.modifier = 'user-picture--large';
       this.dinoTypeSize = 'large';
-    }
+    },
   },
 };
 </script>

--- a/src/components/UserPicture.vue
+++ b/src/components/UserPicture.vue
@@ -64,18 +64,14 @@ export default {
     },
     decidePictureCategory(size) {
       if (size <= 40) {
-        this.modifier = 'user-picture--small';
         this.dinoTypeSize = 'small';
-        return;
-      }
-      if (size <= 100) {
-        this.modifier = 'user-picture--medium';
+      } else if (size <= 100) {
         this.dinoTypeSize = 'medium';
-        return;
+      } else {
+        this.dinoTypeSize = 'large';
       }
-      this.modifier = 'user-picture--large';
-      this.dinoTypeSize = 'large';
-    }
+      this.modifier = `user-picture--${this.dinoTypeSize}`;
+    },
   },
 };
 </script>

--- a/src/components/UserPicture.vue
+++ b/src/components/UserPicture.vue
@@ -55,7 +55,7 @@ export default {
   },
   methods: {
     updateUserPicture() {
-      if (this.picture === null) {
+      if (this.picture === null || this.picture === '/beta/img/user-demo.png') {
         sha256(this.username).then((hash) => {
           const identicon = new Identicon(hash, { size: this.size, format: 'svg' });
           this.src = `data:image/svg+xml;base64,${identicon.toString()}`;
@@ -75,7 +75,7 @@ export default {
       }
       this.modifier = 'user-picture--large';
       this.dinoTypeSize = 'large';
-    },
+    }
   },
 };
 </script>

--- a/src/components/UserPicture.vue
+++ b/src/components/UserPicture.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="'user-picture' + ( modifier ? ' ' + modifier : '')" :style="`width: ${size}px; height: ${size}px;`">
+  <div :class="'user-picture' + ( modifier ? ' ' + modifier : '')">
     <img :class="cls" :src="src" alt="" :width="size" :title="title" role="presentation" aria-hidden="true">
     <DinoType v-if="dinoType" :type="dinoType" :size="dinoTypeSize" />
   </div>
@@ -94,26 +94,50 @@ export default {
     line-height: 1;
     padding: .25em;
   }
-  .user-picture--small .dino-type {
-    font-size: .75em;
-    text-transform: uppercase;
-    letter-spacing: .1em;
-    border-radius: var(--imageRadius) 0;
-    padding: .25em;
+  .user-picture--small {
+    width: 2.5em;
+    height: 2.5em;
   }
-  .user-picture--medium .dino-type {
-    font-size: .75em;
-    letter-spacing: .05em;
-    padding: .3em .6em;
-    border-radius: var(--imageRadius) 0;
+    .user-picture--small .dino-type {
+      font-size: .75em;
+      text-transform: uppercase;
+      letter-spacing: .1em;
+      border-radius: var(--imageRadius) 0;
+      padding: .25em;
+    }
+  .user-picture--medium {
+    width: 6.25em;
+    height: 6.25em;
   }
-  .user-picture--large .dino-type {
-    left: 50%;
-    right: auto;
-    bottom: -.5em;
-    transform: translate(-50%,25%);
-    font-size: .9em;
-    padding: .75em 2em;
-    border-radius: 2em;
+    .user-picture--medium .dino-type {
+      font-size: .75em;
+      letter-spacing: .05em;
+      padding: .3em .6em .3em 1.2em;
+      border-radius: 1em 0 var(--imageRadius);
+    }
+  .user-picture--large /* the 'large' UserPicture is actually medium on small screens */ {
+    width: 6.25em;
+    height: 6.25em;
+  }
+    .user-picture--large .dino-type {
+      font-size: .75em;
+      letter-spacing: .05em;
+      padding: .3em .6em .3em 1.2em;
+      border-radius: 1em 0 var(--imageRadius);
+    }
+  @media (min-width:50em) {
+    .user-picture--large {
+      width: 15em;
+      height: 15em;
+    }
+      .user-picture--large .dino-type {
+        left: 50%;
+        right: auto;
+        bottom: -.5em;
+        transform: translate(-50%,25%);
+        font-size: .9em;
+        padding: .75em 2em;
+        border-radius: 2em;
+      }
   }
 </style>

--- a/src/components/functional/ShowMore.vue
+++ b/src/components/functional/ShowMore.vue
@@ -69,7 +69,6 @@ export default {
 <style>
   .show-more {
     position: relative;
-    font: inherit;
   }
   .show-more--transition .show-more__overflow--enter-active,
   .show-more--transition  .show-more__overflow--leave-active {
@@ -80,6 +79,9 @@ export default {
     opacity: 0;
     z-index: 1;
   }
+    .show-more__button {
+      font: inherit;
+    }
     .show-more__button > svg,
     .show-more__button > img {
       margin-right: 1.5em;

--- a/src/components/functional/ShowMore.vue
+++ b/src/components/functional/ShowMore.vue
@@ -69,6 +69,7 @@ export default {
 <style>
   .show-more {
     position: relative;
+    font: inherit;
   }
   .show-more--transition .show-more__overflow--enter-active,
   .show-more--transition  .show-more__overflow--leave-active {
@@ -79,8 +80,8 @@ export default {
     opacity: 0;
     z-index: 1;
   }
-    .show-more svg,
-    .show-more img {
+    .show-more__button > svg,
+    .show-more__button > img {
       margin-right: 1.5em;
     }
 </style>

--- a/src/views/PageOrgchart.vue
+++ b/src/views/PageOrgchart.vue
@@ -132,7 +132,7 @@ export default {
 }
 @media (min-width: 50em) {
   .org-chart {
-    padding: 0 2em;
+    padding: 2em;
     display: grid;
     grid-template-columns: 1fr 1fr;
     grid-template-rows: auto 1fr;


### PR DESCRIPTION
Notable changes: 

* `size` in `UserPicture` is now a `Number`
* `size` in `UserPicture` is now also used to determine what the Staff/Contributor label ('DinoType') looks like
* styling of `person__photo` in various places is now part of `UserPicture`
* optional `dinoType` prop in `UserPicture` determines if and which label is shown; this is now set to 'Staff' everywhere, we'll want to set it to something more useful when we have real data
* we now have just one link in a `Person`
  * when you tab with keyboard, each person is one tab (was: two)
  * when using screenreader, each person gets read out once (was: twice)