### PR TITLE
Fix linting error in ProfileName component

### DIFF
--- a/src/components/ProfileName.vue
+++ b/src/components/ProfileName.vue
@@ -40,7 +40,7 @@ export default {
   }
   .profile__name h1 {
     margin-bottom: 0;
-  } 
+  }
   .profile__pronoun {
     margin-left: 1em;
   }


### PR DESCRIPTION
Fixes a linting error you get when running `npm run serve`, it's fairly trivial but adds a little confusion for first time installers, the error I was getting is attached below:

```log
Module Warning (from ./node_modules/eslint-loader/index.js):
error: Trailing spaces not allowed (no-trailing-spaces) at src/components/ProfileName.vue:43:4:
  41 |   .profile__name h1 {
  42 |     margin-bottom: 0;
> 43 |   }
     |    ^
  44 |   .profile__pronoun {
  45 |     margin-left: 1em;
  46 |   }

```