### PR TITLE
adding label for Calico namespaceSelector

### DIFF
--- a/k8s/templates/00-namespace.yaml
+++ b/k8s/templates/00-namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+  labels:
+    name: {{ .Values.namespace }}

--- a/k8s/templates/00-namespace.yaml
+++ b/k8s/templates/00-namespace.yaml
@@ -4,4 +4,4 @@ kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
   labels:
-    name: {{ .Values.namespace }}
+    namespace-id: {{ .Values.namespace }}


### PR DESCRIPTION
Calico allows us to block traffic from outside a namespace but it will use a `namespaceSelector` which needs a label rather than a namespace name. I'll create similar pull requests for the other services. Moving forward, it would be useful to add a name label to any new namespace just in case we need to use it.