### PR TITLE
Org chart improvements

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -209,9 +209,10 @@ export default {
     }
   }
 
-  :focus,
-  ::-moz-focus-inner {
+  :focus {
     outline: none;
+  }
+  ::-moz-focus-inner {
     border: 0;
   }
   .focus-styles :focus {

--- a/src/components/OrgNode.vue
+++ b/src/components/OrgNode.vue
@@ -58,7 +58,9 @@ export default {
     if (this.data.username === this.$route.params.username) {
       const e = document.getElementById(`${this.data.username}`);
       if (e) {
-        e.scrollIntoView(false);
+        e.scrollIntoView({
+          block: 'center',
+        });
       }
     }
   },

--- a/src/components/OrgNode.vue
+++ b/src/components/OrgNode.vue
@@ -5,10 +5,10 @@
       <span class="org-node__name">{{ data.firstName }} {{ data.lastName }}</span>
       <span class="org-node__title">{{ data.title }}</span>
     </RouterLink>
-    <ShowMore v-if="children.length > 0" :buttonText="`Expand ${data.firstName} ${data.lastName}`" :alternateButtonText="`Collapse ${data.firstName} ${data.lastName}`" :trace="trace" :prefix="prefix" buttonClass="org-node__toggle" :transition="false" :moveFocus="false" :overflowBefore="false">
+    <ShowMore v-if="children.length > 0" :buttonText="`Expand ${data.firstName} ${data.lastName}`" :alternateButtonText="`Collapse ${data.firstName} ${data.lastName}`" buttonClass="org-node__toggle" :transition="false" :moveFocus="false" :overflowBefore="false" :expanded="expandAllChildren || orgNodeExpanded" @expand-all="handleExpandAll">
       <template slot="overflow">
         <ul v-for="(child, index) in children" :key="index">
-          <OrgNode :children="child.children" :data="child.data" :prefix="`${prefix}-${index}`" :trace="trace"></OrgNode>
+          <OrgNode :children="child.children" :data="child.data" :prefix="`${prefix}-${index}`" :trace="trace" :expandAllChildren="shouldExpandAllChildren"></OrgNode>
         </ul>
       </template>
       <template slot="icon-expanded">
@@ -32,10 +32,27 @@ export default {
     data: Object,
     prefix: String,
     trace: String,
+    expandAllChildren: {
+      type: Boolean,
+      default: false,
+    },
   },
   components: {
     ShowMore,
     UserPicture,
+  },
+  watch: {
+    trace() {
+      if (this.trace || this.prefix) {
+        this.orgNodeExpanded = this.trace.startsWith(`${this.prefix}-`) || this.orgNodeExpanded;
+      }
+      return this.orgNodeExpanded;
+    },
+  },
+  methods: {
+    handleExpandAll() {
+      this.shouldExpandAllChildren = !this.shouldExpandAllChildren;
+    },
   },
   mounted() {
     if (this.data.username === this.$route.params.username) {
@@ -44,6 +61,14 @@ export default {
         e.scrollIntoView(false);
       }
     }
+  },
+  data() {
+    const state = (this.trace && this.trace.startsWith(`${this.prefix}-`));
+
+    return {
+      orgNodeExpanded: state || (this.prefix && !this.prefix.includes('-')),
+      shouldExpandAllChildren: this.expandAllChildren || false,
+    };
   },
 };
 </script>


### PR DESCRIPTION
## Move trace and state to OrgNode

This is new: I've moved the `trace` and `state` stuff to the OrgNode component, as it is specific for org nodes, there are no other `ShowMore` instances that require it. 

## New ShowMore feature: alt click triggers expand all

Alt click on the button of a `ShowMore`, now triggers an event to be emitted that parent components can use for expand/collapse all behaviour.

We use this new feature in, surprise, the org chart. Alt click on a expand/collapse button does expanding and collapsing for all children.