### PR TITLE
make modal controlled (i.e. stateless)

### DIFF
--- a/src/components/functional/Modal.vue
+++ b/src/components/functional/Modal.vue
@@ -1,19 +1,31 @@
 <template>
-    <transition name="modal-">
-      <div class="modal" v-show="isOpen" tabindex="-1" @keyup.esc="isOpen = false" ref="modalEl">
-        <div class="modal__content">
-          <div class="modal__header">
-            <div class="modal__container">
-              <button v-if="closeButton" @click="isOpen = false" class="button button--text-only button--secondary">Close <img src="@/assets/images/x.svg" alt="" width="20" aria-hidden="true" /></button>
-              <h1 v-if="heading">{{ heading }}</h1>
-            </div>
-          </div>
+  <transition name="modal-">
+    <div class="modal" tabindex="-1" @keyup.esc="$emit('close')" ref="modalEl">
+      <div class="modal__content">
+        <div class="modal__header">
           <div class="modal__container">
-            <slot></slot>
+            <button
+              @click="$emit('close')"
+              class="button button--text-only button--secondary"
+              type="button"
+            >
+              Close
+              <img
+                src="@/assets/images/x.svg"
+                alt=""
+                width="20"
+                aria-hidden="true"
+              />
+            </button>
+            <h1 v-if="heading">{{ heading }}</h1>
           </div>
         </div>
+        <div class="modal__container">
+          <slot></slot>
+        </div>
       </div>
-    </transition>
+    </div>
+  </transition>
 </template>
 
 <script>
@@ -23,53 +35,32 @@ export default {
   name: 'Modal',
   props: {
     heading: String,
-    initiallyOpen: Boolean,
-    closeButton: Boolean,
-  },
-  updated() {
-    this.init();
   },
   data() {
     return {
       isOpen: false,
-      focusLocked: false,
       lastFocusedElement: null,
     };
   },
   mounted() {
-    if (this.initiallyOpen) {
-      this.isOpen = true;
-      this.init();
-    }
+    this.lockFocus();
+    this.preventBackgroundScrolling();
   },
   beforeDestroy() {
-    if (this.focusLocked) {
-      this.undoLockFocus();
-      this.enableBackgroundScrolling();
-    }
+    this.undoLockFocus();
+    this.enableBackgroundScrolling();
   },
   methods: {
-    init() {
-      if (this.isOpen) {
-        this.lockFocus();
-        this.preventBackgroundScrolling();
-      } else {
-        this.undoLockFocus();
-        this.enableBackgroundScrolling();
-      }
-    },
     lockFocus() {
       this.lastFocusedElement = document.activeElement;
       bindFocusTrap(this.$refs.modalEl);
       this.$refs.modalEl.focus();
-      this.focusLocked = true;
     },
     undoLockFocus() {
       unbindFocusTrap(this.$refs.modalEl);
       if (this.lastFocusedElement) {
         this.lastFocusedElement.focus();
       }
-      this.focusLocked = false;
     },
     preventBackgroundScrolling() {
       document.body.style.overflow = 'hidden';
@@ -81,68 +72,65 @@ export default {
       document.body.style.position = 'static';
       document.documentElement.style.position = 'static';
     },
-    preventDefault(e) {
-      e.preventDefault();
-    },
   },
 };
 </script>
 
 <style>
-  .modal {
-    position: fixed;
-    width: 100%;
-    height: 100%;
-    background: rgba(0,0,0, .7);
-    display: flex;
-    align-items: center;
-    padding: 1em;
-    top: 0;
-    left: 0;
-    opacity: 1;
-    z-index: var(--layerModal);
-    overflow: auto;
+.modal {
+  position: fixed;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  padding: 1em;
+  top: 0;
+  left: 0;
+  opacity: 1;
+  z-index: var(--layerModal);
+  overflow: auto;
+}
+.modal--enter-active,
+.modal--leave-active {
+  transition: all 0.2s ease-in-out;
+}
+.modal--enter {
+  opacity: 0;
+}
+.modal__content {
+  width: 100%;
+  background: var(--white);
+  padding: 1.5em;
+  margin: auto;
+  position: relative;
+}
+.org-chart__preview .modal__content {
+  min-height: calc(100% + 1em);
+  margin-bottom: -1em;
+}
+.modal__container {
+  max-width: 32em;
+  margin: 0 auto;
+}
+.modal__header {
+  padding: 1em;
+  margin: -1.5em -1.5em 0;
+  border: 1px solid var(--midGrey);
+  position: relative;
+}
+@media (min-width: 57.5em) {
+  .modal__header {
+    padding: 3em 1em 1em;
   }
-  .modal--enter-active,
-  .modal--leave-active {
-    transition: all .2s ease-in-out;
-  }
-  .modal--enter {
-    opacity: 0;
-  }
-    .modal__content {
-      width: 100%;
-      background: var(--white);
-      padding: 1.5em;
-      margin: auto;
-      position: relative;
-    }
-    .org-chart__preview .modal__content {
-      min-height: calc( 100% + 1em);
-      margin-bottom: -1em;
-    }
-    .modal__container {
-      max-width: 32em;
-      margin: 0 auto;
-    }
-    .modal__header {
-      padding: 1em;
-      margin: -1.5em -1.5em 0;
-      border: 1px solid var(--midGrey);
-      position: relative;
-    }
-    @media (min-width: 57.5em) {
-      .modal__header {
-        padding: 3em 1em 1em;
-      }
-    }
-      .modal__header h1 {
-        font-size: 2.25em;
-        margin-bottom: 0;
-      }
-      .modal__header button {
-        position: absolute;
-        top: 1em;
-        right: 1em;
-      }
+}
+.modal__header h1 {
+  font-size: 2.25em;
+  margin-bottom: 0;
+}
+.modal__header button {
+  position: absolute;
+  top: 1em;
+  right: 1em;
+}
 </style>

--- a/src/components/functional/Modal.vue
+++ b/src/components/functional/Modal.vue
@@ -38,7 +38,6 @@ export default {
   },
   data() {
     return {
-      isOpen: false,
       lastFocusedElement: null,
     };
   },

--- a/src/views/PageOrgchart.vue
+++ b/src/views/PageOrgchart.vue
@@ -30,8 +30,7 @@
             ></ProfilePreview>
             <Modal
               v-else
-              :initiallyOpen="true"
-              :closeButton="false"
+              v-on:close="$router.push({ name: 'Orgchart' })"
               ref="modalEl"
             >
               <ProfilePreview v-bind="data.profile"></ProfilePreview>
@@ -109,13 +108,6 @@ export default {
     },
     openedFromOrgNode() {
       return this.$route.params.openedFromOrgNode;
-    },
-  },
-  watch: {
-    desktopView() {
-      if (this.modalEl && this.desktopView === true) {
-        this.modalEl.isOpen = true;
-      }
     },
   },
   methods: {


### PR DESCRIPTION
Maybe I should've made that PR against master? Not sure, I "need" it for the picture modal.

It's more of a recommendation, I can easily hack around it, but here's my reasoning:
Modal handling is simpler when it doesn't have its own state, i.e. the parent component decides when it should be visible. The modal also emits a `close` event (on Escape or when the close button is clicked), which for the PageOrgChart is used to navigate back.
It has the additional benefit of simplifying the code, as the focus lock only has to happen on mount now (as the modal can't be hidden but mounted).

~There was a closeButton prop which wasn't used, I think because the name used in PageOrgChart was prefixed with an unnecessary `:`. Though I might be missing syntactical nuances here. Lmk if you want it back in.~ Ah nevermind, forgot about the `v-bind`-shorthand. Though that makes me wonder why it didn't work.