### PR TITLE
Lift options state up

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
     'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
     'linebreak-style': 'off',
+    'no-param-reassign': 'off',
   },
   parserOptions: {
     parser: 'babel-eslint',

--- a/src/assets/js/display-levels.js
+++ b/src/assets/js/display-levels.js
@@ -1,5 +1,4 @@
-<script>
-const DISPLAY_LEVELS = {
+export const DISPLAY_LEVELS = {
   public: {
     label: 'Public',
     value: 'public',
@@ -46,11 +45,6 @@ const VALID_DISPLAY_LEVELS = {
   username: DISPLAY_PUBLIC_ONLY,
 };
 
-export default {
-  methods: {
-    displayLevelsFor(field) {
-      return VALID_DISPLAY_LEVELS[field] || DISPLAY_ANY;
-    },
-  },
-};
-</script>
+export function displayLevelsFor(field) {
+  return VALID_DISPLAY_LEVELS[field] || DISPLAY_ANY;
+}

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -6,7 +6,7 @@
       :value="value"
       :id="id"
       :checked="checked"
-      @input="$emit('input', $event.target.value)"
+      @input="$event.target.checked && $emit('input', $event.target.value)"
     />
     <label :for="id" @click="$emit('close-list')">
       <Icon

--- a/src/components/Option.vue
+++ b/src/components/Option.vue
@@ -5,8 +5,8 @@
       :name="groupId"
       :value="value"
       :id="id"
-      v-model="currentValue"
-      @change="emitChoice"
+      :checked="checked"
+      @input="$emit('input', $event.target.value)"
     />
     <label :for="id" @click="$emit('close-list')">
       <Icon
@@ -32,6 +32,7 @@ export default {
     label: String,
     groupId: String,
     value: String,
+    checked: Boolean,
     id: String,
     expandedShowIcon: {
       type: Boolean,
@@ -42,25 +43,8 @@ export default {
       default: true,
     },
   },
-  methods: {
-    emitChoice() {
-      this.$emit('option-picked', {
-        label: this.label,
-        value: this.currentValue,
-        icon: this.icon,
-      });
-    },
-  },
   components: {
     Icon,
-  },
-  mounted() {
-    this.emitChoice();
-  },
-  data() {
-    return {
-      currentValue: '',
-    };
   },
 };
 </script>

--- a/src/components/Options.vue
+++ b/src/components/Options.vue
@@ -5,15 +5,15 @@
       @keydown.up.down.prevent="toggleOptions"
       type="button"
       :ref="`optionToggle-${id}`"
-      :title="this.currentLabel"
+      :title="selectedLabel"
       class="options__toggle"
     >
       <span class="visually-hidden">Open {{ label }}</span>
-      <template v-if="collapsedShowLabel">{{ this.currentLabel }}</template>
-      <span v-else class="visually-hidden">{{ this.currentLabel }}</span>
+      <template v-if="collapsedShowLabel">{{ selectedLabel }}</template>
+      <span v-else class="visually-hidden">{{ selectedLabel }}</span>
       <Icon
-        v-if="collapsedShowIcon && this.currentIcon"
-        :id="this.currentIcon"
+        v-if="collapsedShowIcon && selectedOption && selectedOption.icon"
+        :id="selectedOption && selectedOption.icon"
         :width="17"
         :height="17"
         aria-hidden="true"
@@ -22,17 +22,18 @@
     </button>
     <fieldset @keydown.enter.prevent="closeList">
       <legend class="visually-hidden">{{ label }}</legend>
-      <ul class="options__list" v-show="this.open" :ref="`optionList-${id}`">
+      <ul class="options__list" v-show="open" :ref="`optionList-${id}`">
         <Option
           v-for="(option, index) in options"
           :key="index"
           :groupId="id"
           :label="option.label"
           :value="option.value"
+          :checked="option.value === value"
           :icon="option.icon"
           :id="`option-${id}-${index}`"
           :bind="{ expandedShowIcon, expandedShowLabel }"
-          @option-picked="honourChoice"
+          @input="$emit('input', value)"
           @close-list="closeList"
         />
       </ul>
@@ -81,9 +82,9 @@ export default {
       if (this.open) {
         this.open = false;
       } else {
+        const list = this.$refs[`optionList-${this.id}`];
         const optionToFocus =
-          this.$refs[`optionList-${this.id}`].querySelector('input:checked') ||
-          this.$refs[`optionList-${this.id}`].querySelector('input');
+          list.querySelector('input:checked') || list.querySelector('input');
 
         this.open = true;
 
@@ -93,12 +94,6 @@ export default {
           });
         }
       }
-    },
-    honourChoice(data) {
-      this.currentIcon = data.icon;
-      this.currentValue = data.value;
-      this.currentLabel = data.label;
-      this.$emit('input', data.value);
     },
     closeList() {
       this.open = false;
@@ -116,16 +111,17 @@ export default {
   },
   data() {
     return {
-      currentValue: '',
-      currentLabel: '',
-      currentIcon: null,
       open: false,
     };
   },
-  created() {
-    if (this.defaultToFirst) {
-      this.currentLabel = this.options[0].label;
-    }
+  computed: {
+    selectedOption() {
+      const { options, value } = this.$props;
+      return options.find((o) => o.value === value);
+    },
+    selectedLabel() {
+      return this.selectedOption ? this.selectedOption.label : null;
+    },
   },
 };
 </script>

--- a/src/components/Select.vue
+++ b/src/components/Select.vue
@@ -33,7 +33,7 @@
           :icon="option.icon"
           :id="`option-${id}-${index}`"
           :bind="{ expandedShowIcon, expandedShowLabel }"
-          @input="$emit('input', value)"
+          @input="$emit('input', $event)"
           @close-list="closeList"
         />
       </ul>
@@ -46,16 +46,12 @@ import Icon from '@/components/Icon.vue';
 import Option from '@/components/Option.vue';
 
 export default {
-  name: 'Options',
+  name: 'Select',
   props: {
     label: String,
     id: String,
     value: String,
     options: Array,
-    defaultToFirst: {
-      type: Boolean,
-      default: false,
-    },
     collapsedShowIcon: {
       type: Boolean,
       default: true,
@@ -117,7 +113,7 @@ export default {
   computed: {
     selectedOption() {
       const { options, value } = this.$props;
-      return options.find((o) => o.value === value);
+      return options.find((o) => o.value === value) || options[0];
     },
     selectedLabel() {
       return this.selectedOption ? this.selectedOption.label : null;
@@ -148,7 +144,6 @@ export default {
   background-color: var(--white);
   box-shadow: 0 0.125em 0.25em 0.125em rgba(210, 210, 210, 0.5);
   text-align: left;
-  padding-left: 0;
   z-index: calc(var(--layerModal) - 1);
   position: absolute;
   top: 3.5em;

--- a/src/components/forms/EditPersonalInfo.vue
+++ b/src/components/forms/EditPersonalInfo.vue
@@ -56,7 +56,6 @@
           <Options
             label="Select pronoun"
             id="field-pronouns"
-            :defaultToFirst="true"
             class="options--chevron"
             v-model="pronouns.value"
             :options="[
@@ -198,7 +197,7 @@
 import Options from '@/components/Options.vue';
 
 import { MUTATE_PROFILE, DISPLAY_PROFILE } from '@/queries/profile';
-import DisplayLevelsMixin from '@/components/mixins/DisplayLevelsMixin.vue';
+import { displayLevelsFor, DISPLAY_LEVELS } from '@/assets/js/display-levels';
 
 export default {
   name: 'EditPersonalInfo',
@@ -209,8 +208,8 @@ export default {
   components: {
     Options,
   },
-  mixins: [DisplayLevelsMixin],
   methods: {
+    displayLevelsFor,
     cancelEdit() {
       this.$emit('cancel-edit');
     },
@@ -251,38 +250,16 @@ export default {
     return {
       displayProfile: DISPLAY_PROFILE,
       mutateProfile: MUTATE_PROFILE,
-      alternativeName: {
-        value: this.initialValues.alternativeName.value,
-        display: this.initialValues.alternativeName.display,
-      },
-      firstName: {
-        value: this.initialValues.firstName.value,
-        display: this.initialValues.firstName.display,
-      },
-      lastName: {
-        value: this.initialValues.lastName.value,
-        display: this.initialValues.lastName.display,
-      },
-      funTitle: {
-        value: this.initialValues.funTitle.value,
-        display: this.initialValues.funTitle.value,
-      },
-      location: {
-        value: this.initialValues.location.value,
-        display: this.initialValues.location.display,
-      },
-      pronouns: {
-        value: this.initialValues.pronouns.value,
-        display: this.initialValues.pronouns.display,
-      },
-      timezone: {
-        value: this.initialValues.timezone.value,
-        display: this.initialValues.timezone.display,
-      },
-      description: {
-        value: this.initialValues.description.value,
-        display: this.initialValues.description.display,
-      },
+      ...Object.entries(this.initialValues).reduce(
+        (obj, [key, { value, display }]) => {
+          obj[key] = {
+            value,
+            display: display || DISPLAY_LEVELS.public.value,
+          };
+          return obj;
+        },
+        {},
+      ),
       privacySettings: {
         defaultToFirst: true,
         collapsedShowIcon: true,

--- a/src/components/forms/EditPersonalInfo.vue
+++ b/src/components/forms/EditPersonalInfo.vue
@@ -27,7 +27,7 @@
           <label for="field-first-name">First name</label>
           <input type="text" id="field-first-name" v-model="firstName.value" />
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="First name privacy levels"
               id="field-first-name-privacy"
               v-bind="privacySettings"
@@ -41,7 +41,7 @@
           <label for="field-last-name">Last name</label>
           <input type="text" id="field-last-name" v-model="lastName.value" />
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="Last name privacy levels"
               id="field-last-name-privacy"
               v-bind="privacySettings"
@@ -53,7 +53,7 @@
           <hr role="presentation" />
 
           <div class="edit-personal-info__label">Gender pronouns</div>
-          <Options
+          <Select
             label="Select pronoun"
             id="field-pronouns"
             class="options--chevron"
@@ -81,9 +81,9 @@
               },
             ]"
           >
-          </Options>
+          </Select>
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="Pronoun privacy levels"
               id="field-pronoun-privacy"
               v-bind="privacySettings"
@@ -101,7 +101,7 @@
             v-model="alternativeName.value"
           />
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="Alternative name privacy levels"
               id="field-alt-name-privacy"
               v-bind="privacySettings"
@@ -124,7 +124,7 @@
             v-model="funTitle.value"
           />
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="Fun title privacy levels"
               id="field-fun-title-privacy"
               v-bind="privacySettings"
@@ -137,7 +137,7 @@
           <label for="field-location">Location</label>
           <input type="text" id="field-location" v-model="location.value" />
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="Location privacy levels"
               id="field-location-privacy"
               v-bind="privacySettings"
@@ -150,7 +150,7 @@
           <label for="field-timezone">Timezone</label>
           <input type="text" id="field-timezone" v-model="timezone.value" />
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="Timezone privacy levels"
               id="field-timezone-privacy"
               v-bind="privacySettings"
@@ -169,7 +169,7 @@
           <label for="field-bio">Bio</label>
           <textarea id="field-bio" v-model="description.value"></textarea>
           <div class="edit-personal-info__privacy">
-            <Options
+            <Select
               label="Bio privacy levels"
               id="field-bio-privacy"
               v-bind="privacySettings"
@@ -194,7 +194,7 @@
 </template>
 
 <script>
-import Options from '@/components/Options.vue';
+import Select from '@/components/Select.vue';
 
 import { MUTATE_PROFILE, DISPLAY_PROFILE } from '@/queries/profile';
 import { displayLevelsFor, DISPLAY_LEVELS } from '@/assets/js/display-levels';
@@ -206,7 +206,7 @@ export default {
     initialValues: Object,
   },
   components: {
-    Options,
+    Select,
   },
   methods: {
     displayLevelsFor,
@@ -261,7 +261,6 @@ export default {
         {},
       ),
       privacySettings: {
-        defaultToFirst: true,
         collapsedShowIcon: true,
         collapsedShowLabel: false,
         expandedShowIcon: true,


### PR DESCRIPTION
- Rename `Options` to `Select`
- Lift selected value state up
  - Options maintains less state now, selected value is a prop, currently selected option computed based on it (and options)
  - @hidde a good read on that topic in the React context: https://reactjs.org/docs/lifting-state-up.html Haven't found a similar article with a Vue contex
- turn DisplayLevelsMixin into a regular old-js file, as I needed the default display state
- removed defaultToFirst and made that the default behavior. So that it behaves more like regular-ol select's
- fill the EditPersonalInfo-s data based on all the given initialValues (less explicit, but also no repetition)