### PR TITLE
Clean up Profile component and add initial account editing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -922,9 +922,9 @@
       }
     },
     "@types/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
     "@types/strip-bom": {
@@ -1049,9 +1049,9 @@
       }
     },
     "@vue/cli-overlay": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-3.4.1.tgz",
-      "integrity": "sha512-mO0680PClML4lj6ruH+YV3BwPjxvJ4HkgsyMlmCyOZimQBxifvjK/6MX2p179M1QoJtSaz8omRJ7a6/mAP5SXg==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/cli-overlay/-/cli-overlay-3.5.1.tgz",
+      "integrity": "sha512-DqzfkbKJfuzcNbJouA7ZaLX77xn7FCcVUJaPYVH8qm3pNhIz2tmbfN6WVBLU8XC5FNFFWzLjHmg9rpaEBq7RCA==",
       "dev": true
     },
     "@vue/cli-plugin-babel": {
@@ -1145,22 +1145,22 @@
       }
     },
     "@vue/cli-service": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.4.1.tgz",
-      "integrity": "sha512-HAF2yeafVJVKiBaapvbVIK4cM+lDU4r6aJzbKLOonzQrnI45T2NLEvYC+9uW7C5LvC1d4g1XUx25Q8ixSBKegQ==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@vue/cli-service/-/cli-service-3.5.1.tgz",
+      "integrity": "sha512-c3xzj2+yrnyziDvkKBTD1cB2jDBs0E4G5gk21hHzvAwzyNSpMPTqwAaeAfUtKHWSgs1dKxi/gURfIgFGUJPn+Q==",
       "dev": true,
       "requires": {
         "@intervolga/optimize-cssnano-plugin": "^1.0.5",
         "@soda/friendly-errors-webpack-plugin": "^1.7.1",
-        "@vue/cli-overlay": "^3.4.1",
-        "@vue/cli-shared-utils": "^3.4.1",
-        "@vue/component-compiler-utils": "^2.5.2",
+        "@vue/cli-overlay": "^3.5.1",
+        "@vue/cli-shared-utils": "^3.5.1",
+        "@vue/component-compiler-utils": "^2.6.0",
         "@vue/preload-webpack-plugin": "^1.1.0",
         "@vue/web-component-wrapper": "^1.2.0",
         "acorn": "^6.1.0",
         "acorn-walk": "^6.1.1",
         "address": "^1.0.3",
-        "autoprefixer": "^9.4.7",
+        "autoprefixer": "^9.4.8",
         "cache-loader": "^2.0.1",
         "case-sensitive-paths-webpack-plugin": "^2.2.0",
         "chalk": "^2.4.2",
@@ -1171,6 +1171,7 @@
         "cssnano": "^4.1.10",
         "debug": "^4.1.1",
         "dotenv": "^6.2.0",
+        "dotenv-expand": "^4.2.0",
         "escape-string-regexp": "^1.0.5",
         "file-loader": "^3.0.1",
         "fs-extra": "^7.0.1",
@@ -1195,19 +1196,39 @@
         "terser-webpack-plugin": "^1.2.2",
         "thread-loader": "^2.1.2",
         "url-loader": "^1.1.2",
-        "vue-loader": "^15.6.2",
+        "vue-loader": "^15.6.4",
         "webpack": ">=4 < 4.29",
         "webpack-bundle-analyzer": "^3.0.4",
         "webpack-chain": "^4.11.0",
-        "webpack-dev-server": "^3.1.14",
+        "webpack-dev-server": "^3.2.0",
         "webpack-merge": "^4.2.1",
         "yorkie": "^2.0.0"
       },
       "dependencies": {
+        "@vue/cli-shared-utils": {
+          "version": "3.5.1",
+          "resolved": "https://registry.npmjs.org/@vue/cli-shared-utils/-/cli-shared-utils-3.5.1.tgz",
+          "integrity": "sha512-hCB7UbKeeC41w2Q8+Q7jmw3gHdq+ltRqp80S3uDRRGxwiOhxrSmdBHMzKUjh01L8bXOBRgvLey+BERi1Nj9n6Q==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "execa": "^1.0.0",
+            "joi": "^14.3.0",
+            "launch-editor": "^2.2.1",
+            "lru-cache": "^5.1.1",
+            "node-ipc": "^9.1.1",
+            "opn": "^5.3.0",
+            "ora": "^3.1.0",
+            "request": "^2.87.0",
+            "request-promise-native": "^1.0.7",
+            "semver": "^5.5.0",
+            "string.prototype.padstart": "^3.0.0"
+          }
+        },
         "acorn": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-          "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
           "dev": true
         },
         "chalk": {
@@ -1219,6 +1240,15 @@
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
+          }
+        },
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
           }
         },
         "parse-json": {
@@ -1246,6 +1276,12 @@
           "version": "5.6.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "dev": true
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true
         }
       }
@@ -1652,9 +1688,9 @@
       "dev": true
     },
     "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
       "dev": true
     },
     "ansi-escapes": {
@@ -2307,17 +2343,25 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "9.4.9",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.9.tgz",
-      "integrity": "sha512-OyUl7KvbGBoFQbGQu51hMywz1aaVeud/6uX8r1R1DNcqFvqGUUy6+BDHnAZE8s5t5JyEObaSw+O1DpAdjAmLuw==",
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.5.0.tgz",
+      "integrity": "sha512-hMKcyHsZn5+qL6AUeP3c8OyuteZ4VaUlg+fWbyl8z7PqsKHF/Bf8/px3K6AT8aMzDkBo8Bc11245MM+itDBOxQ==",
       "dev": true,
       "requires": {
         "browserslist": "^4.4.2",
-        "caniuse-lite": "^1.0.30000939",
+        "caniuse-lite": "^1.0.30000947",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.14",
         "postcss-value-parser": "^3.3.1"
+      },
+      "dependencies": {
+        "caniuse-lite": {
+          "version": "1.0.30000953",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000953.tgz",
+          "integrity": "sha512-2stdF/q5MZTDhQ6uC65HWbSgI9UMKbc7+HKvlwH5JBIslKoD/J9dvabP4J4Uiifu3NljbHj3iMpfYflLSNt09A==",
+          "dev": true
+        }
       }
     },
     "aws-sign2": {
@@ -3918,16 +3962,16 @@
       }
     },
     "compression": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.3.tgz",
-      "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.4.tgz",
+      "integrity": "sha512-jaSIDzP9pZVS4ZfQ+TzvtiWhdpFhE2RDHz8QJkpX9SIpLq88VueF5jJw6t+6CUQcAoA6t+x89MLrWAqpfDE8iQ==",
       "dev": true,
       "requires": {
         "accepts": "~1.3.5",
         "bytes": "3.0.0",
-        "compressible": "~2.0.14",
+        "compressible": "~2.0.16",
         "debug": "2.6.9",
-        "on-headers": "~1.0.1",
+        "on-headers": "~1.0.2",
         "safe-buffer": "5.1.2",
         "vary": "~1.1.2"
       },
@@ -4232,15 +4276,14 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
+        "js-yaml": "^3.13.0",
         "parse-json": "^4.0.0"
       },
       "dependencies": {
@@ -4712,9 +4755,9 @@
       "dev": true
     },
     "default-gateway": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.1.2.tgz",
-      "integrity": "sha512-xhJUAp3u02JsBGovj0V6B6uYhKCUOmiNc8xGmReUwGu77NmvcpxPVB0pCielxMFumO7CmXBG02XjM8HB97k8Hw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
+      "integrity": "sha512-h6sMrVB1VMWVrW13mSc6ia/DwYYw5MN6+exNu1OaJeFac5aSAvwM7lZ0NVfTABuSkQelr4h5oebg3KB1XPdjgA==",
       "dev": true,
       "requires": {
         "execa": "^1.0.0",
@@ -5039,9 +5082,15 @@
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
       "dev": true
     },
+    "dotenv-expand": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-4.2.0.tgz",
+      "integrity": "sha1-3vHxyl1gWdJKdm5YeULCEQbOEnU=",
+      "dev": true
+    },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
       "dev": true
     },
@@ -7638,7 +7687,7 @@
     },
     "html-webpack-plugin": {
       "version": "3.2.0",
-      "resolved": "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
       "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
       "dev": true,
       "requires": {
@@ -7692,9 +7741,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7712,7 +7761,7 @@
     },
     "http-errors": {
       "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "dev": true,
       "requires": {
@@ -8700,7 +8749,7 @@
     },
     "is-obj": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
@@ -9604,9 +9653,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
+      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",
@@ -9923,12 +9972,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",
       "integrity": "sha1-vsECT4WxvZbL6kBbI8FK1kQ6b4E=",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
       "dev": true
     },
     "lodash.kebabcase": {
@@ -12153,9 +12196,9 @@
       "dev": true
     },
     "querystringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.0.tgz",
-      "integrity": "sha512-sluvZZ1YiTLD5jsqZcDmFyV2EwToyXZBfpoVOmktMmW+VEnhgakFHnasVph65fOjGPTWN0Nw3+XQaSeMayr0kg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
+      "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
     },
     "randomatic": {
@@ -13877,9 +13920,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -15042,9 +15085,9 @@
       }
     },
     "vue-loader": {
-      "version": "15.6.4",
-      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.6.4.tgz",
-      "integrity": "sha512-GImqWcO3OsiRYS/zfMhmthFd1xwL68AAE5gAHhzNCI4SLNSxIlB9YmjgJS89anqViWSyl0mnAmyXNYHs7sydFw==",
+      "version": "15.7.0",
+      "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.7.0.tgz",
+      "integrity": "sha512-x+NZ4RIthQOxcFclEcs8sXGEWqnZHodL2J9Vq+hUz+TDZzBaDIh1j3d9M2IUlTjtrHTZy4uMuRdTi8BGws7jLA==",
       "dev": true,
       "requires": {
         "@vue/component-compiler-utils": "^2.5.1",
@@ -15477,12 +15520,13 @@
       }
     },
     "webpack-bundle-analyzer": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.0.4.tgz",
-      "integrity": "sha512-ggDUgtKuQki4vmc93Ej65GlYxeCUR/0THa7gA+iqAGC2FFAxO+r+RM9sAUa8HWdw4gJ3/NZHX/QUcVgRjdIsDg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.1.0.tgz",
+      "integrity": "sha512-nyDyWEs7C6DZlgvu1pR1zzJfIWSiGPbtaByZr8q+Fd2xp70FuM/8ngCJzj3Er1TYRLSFmp1F1OInbEm4DZH8NA==",
       "dev": true,
       "requires": {
-        "acorn": "^5.7.3",
+        "acorn": "^6.0.7",
+        "acorn-walk": "^6.1.1",
         "bfj": "^6.1.1",
         "chalk": "^2.4.1",
         "commander": "^2.18.0",
@@ -15496,6 +15540,12 @@
         "ws": "^6.0.0"
       },
       "dependencies": {
+        "acorn": {
+          "version": "6.1.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+          "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+          "dev": true
+        },
         "commander": {
           "version": "2.19.0",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
@@ -15503,9 +15553,9 @@
           "dev": true
         },
         "ws": {
-          "version": "6.1.4",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-          "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
+          "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
           "dev": true,
           "requires": {
             "async-limiter": "~1.0.0"
@@ -15524,9 +15574,9 @@
       }
     },
     "webpack-dev-middleware": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.0.tgz",
-      "integrity": "sha512-oeXA3m+5gbYbDBGo4SvKpAHJJEGMoekUbHgo1RK7CP1sz7/WOSeu/dWJtSTk+rzDCLkPwQhGocgIq6lQqOyOwg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.6.1.tgz",
+      "integrity": "sha512-XQmemun8QJexMEvNFbD2BIg4eSKrmSIMrTfnl2nql2Sc6OGAYFyb8rwuYrCjl/IiEYYuyTEiimMscu7EXji/Dw==",
       "dev": true,
       "requires": {
         "memory-fs": "^0.4.1",
@@ -15639,15 +15689,21 @@
           }
         },
         "mem": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.1.0.tgz",
-          "integrity": "sha512-I5u6Q1x7wxO0kdOpYBB28xueHADYps5uty/zg936CiG8NTe5sJL8EjrCuLneuDW3PlMdZBGDIn8BirEVdovZvg==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
+          "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
-            "mimic-fn": "^1.0.0",
+            "mimic-fn": "^2.0.0",
             "p-is-promise": "^2.0.0"
           }
+        },
+        "mimic-fn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
+          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+          "dev": true
         },
         "os-locale": {
           "version": "3.1.0",
@@ -15661,9 +15717,9 @@
           }
         },
         "p-limit": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -15679,9 +15735,9 @@
           }
         },
         "p-try": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-          "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.1.0.tgz",
+          "integrity": "sha512-H2RyIJ7+A3rjkwKC2l5GGtU4H1vkxKCAGsWasNVd0Set+6i4znxbWy6/j16YDPJDWxhsgZiKAstMEP8wCdSpjA==",
           "dev": true
         },
         "schema-utils": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@vue/cli-plugin-babel": "^3.4.1",
     "@vue/cli-plugin-eslint": "^3.4.1",
     "@vue/cli-plugin-unit-jest": "^3.5.1",
-    "@vue/cli-service": "^3.4.1",
+    "@vue/cli-service": "^3.5.1",
     "@vue/eslint-config-airbnb": "^4.0.0",
     "@vue/test-utils": "^1.0.0-beta.29",
     "babel-core": "7.0.0-bridge.0",

--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -56,5 +56,17 @@ export default {
       return null;
     },
   },
+  computed: {
+    selectableAccounts() {
+      const selectables = Object.entries(EXTERNAL_ACCOUNTS).map(([k, v]) => {
+        return {
+          label: v.text,
+          value: k,
+        };
+      });
+
+      return selectables;
+    },
+  },
 };
 </script>

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -6,6 +6,7 @@
           (this.editing === 'personal-info' ? ' profile__section--editing' : '')
       "
     >
+      <Toast :content="toastContent" @reset-toast="toastContent = ''"></Toast>
       <EditPersonalInfo
         v-if="this.editing === 'personal-info'"
         v-bind="{
@@ -44,7 +45,6 @@
           userOnOwnProfile,
         }"
       />
-      <Toast :content="toastContent" @reset-toast="toastContent = ''"></Toast>
     </div>
     <ProfileNav
       :links="profileNav"

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -9,7 +9,6 @@
       <EditPersonalInfo
         v-if="this.editing === 'personal-info'"
         v-bind="{
-          picture,
           staffInformation,
           initialValues: {
             alternativeName,
@@ -19,6 +18,7 @@
             funTitle,
             location,
             primaryUsername,
+            picture,
             pronouns,
             timezone,
           },

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -83,10 +83,19 @@
         v-bind="{ primaryEmail, phoneNumbers, userOnOwnProfile }"
       ></ViewContact>
     </section>
-    <section v-if="sections.accounts" class="profile__section">
+    <section
+      v-if="sections.accounts"
+      :class="
+        'profile__section' +
+          (this.editing === 'accounts' ? ' profile__section--editing' : '')
+      "
+    >
       <a id="nav-accounts" class="profile__anchor"></a>
-      <EditAccounts v-if="this.editing === 'accounts'"></EditAccounts>
-      <ViewAccounts v-else v-bind="{ uris }"></ViewAccounts>
+      <EditAccounts
+        v-if="this.editing === 'accounts'"
+        v-bind="{ username: primaryUsername.value, initialValues: { uris } }"
+      ></EditAccounts>
+      <ViewAccounts v-else v-bind="{ uris, userOnOwnProfile }"></ViewAccounts>
     </section>
     <EmptyCard v-else title="Accounts" message="No accounts have been added"
       ><a id="nav-accounts" class="profile__anchor"></a
@@ -102,7 +111,6 @@
       <EditLanguages
         v-if="this.editing === 'languages'"
         v-bind="{
-          username: primaryUsername.value,
           initialValues: {
             languages,
           },

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -52,22 +52,7 @@
     ></ProfileNav>
     <section v-if="staffInformation.staff.value" class="profile__section">
       <a id="nav-relations" class="profile__anchor"></a>
-      <header class="profile__section-header">
-        <h2>Colleagues</h2>
-        <RouterLink
-          :to="{
-            name: 'OrgchartHighlight',
-            params: { username: primaryUsername.value },
-          }"
-          class="button button--secondary button--small"
-        >
-          <Icon id="org-chart" :width="16" :height="16" />
-          Org Chart
-          <Icon id="chevron-right" :width="18" :height="18" />
-        </RouterLink>
-      </header>
-      <ReportingStructure :username="primaryUsername.value">
-      </ReportingStructure>
+      <ViewRelations v-bind="primaryUsername"></ViewRelations>
     </section>
     <EmptyCard
       title="Identities"
@@ -100,47 +85,14 @@
     </section>
     <section v-if="sections.accounts" class="profile__section">
       <a id="nav-accounts" class="profile__anchor"></a>
-      <header class="profile__section-header">
-        <h2>Accounts</h2>
-      </header>
-      <div class="profile__external-accounts">
-        <div v-if="accounts.mozilla.length">
-          <h3>Mozilla</h3>
-          <IconBlockList>
-            <IconBlock
-              v-for="(acc, index) in accounts.mozilla"
-              :key="`acc-moz-${index}`"
-              :heading="acc.text"
-              :icon="acc.icon"
-            >
-              <a :href="acc.value" target="_blank" rel="noreferrer noopener">{{
-                acc.value
-              }}</a>
-            </IconBlock>
-          </IconBlockList>
-        </div>
-        <div v-if="accounts.other.length">
-          <h3>Elsewhere</h3>
-          <IconBlockList>
-            <IconBlock
-              v-for="(acc, index) in accounts.other"
-              :key="`acc-other-${index}`"
-              :heading="acc.text"
-              :icon="acc.icon"
-            >
-              <a :href="acc.value" target="_blank" rel="noreferrer noopener">{{
-                acc.value
-              }}</a>
-            </IconBlock>
-          </IconBlockList>
-        </div>
-      </div>
+      <EditAccounts v-if="this.editing === 'accounts'"></EditAccounts>
+      <ViewAccounts v-else v-bind="{ uris }"></ViewAccounts>
     </section>
     <EmptyCard v-else title="Accounts" message="No accounts have been added"
       ><a id="nav-accounts" class="profile__anchor"></a
     ></EmptyCard>
     <section
-      v-if="languagesSorted && languagesSorted.length > 0"
+      v-if="sections.languages"
       :class="
         'profile__section' +
           (this.editing === 'languages' ? ' profile__section--editing' : '')
@@ -159,52 +111,31 @@
       ></EditLanguages>
       <ViewLanguages
         v-else
-        v-bind="{ languages: languagesSorted, userOnOwnProfile }"
+        v-bind="{ languages, userOnOwnProfile }"
       ></ViewLanguages>
     </section>
     <EmptyCard v-else title="Languages" message="No languages have been added">
       <a id="nav-languages" class="profile__anchor"></a
     ></EmptyCard>
-    <section v-if="(tagsSorted || []).length > 0" class="profile__section">
+    <section
+      v-if="sections.tags"
+      :class="
+        'profile__section' +
+          (this.editing === 'tags' ? ' profile__section--editing' : '')
+      "
+    >
       <a id="nav-tags" class="profile__anchor"></a>
-      <header class="profile__section-header">
-        <h2>Tags</h2>
-      </header>
-      <Tag
-        v-for="(tag, index) in tagsSorted"
-        :tag="tag"
-        :key="`tag-${index}`"
-      />
+      <EditTags v-if="this.editing === 'tags'"></EditTags>
+      <ViewTags v-else v-bind="{ tags, userOnOwnProfile }"></ViewTags>
     </section>
     <EmptyCard v-else title="Tags" message="No tags have been added">
       <a id="nav-tags" class="profile__anchor"></a
     ></EmptyCard>
     <section class="profile__section" v-if="pgpPublicKeys || sshPublicKeys">
-      <h3>Keys</h3>
-      <template
-        v-if="pgpPublicKeys && Object.keys(pgpPublicKeys.values).length > 0"
-      >
-        <h4 class="visually-hidden">PGP</h4>
-        <Key
-          v-for="[key, value] in Object.entries(pgpPublicKeys.values)"
-          type="PGP"
-          :title="key"
-          :content="value"
-          :key="`pgp-${key}`"
-        />
-      </template>
-      <template
-        v-if="sshPublicKeys && Object.keys(sshPublicKeys.values).length > 0"
-      >
-        <h4 class="visually-hidden">SSH</h4>
-        <Key
-          v-for="[key, value] in Object.entries(sshPublicKeys.values)"
-          type="SSH"
-          :title="key"
-          :content="value"
-          :key="`ssh-${key}`"
-        />
-      </template>
+      <EditKeys v-if="this.editing === 'keys'"> </EditKeys>
+      <ViewKeys
+        v-bind="{ pgpPublicKeys, sshPublicKeys, userOnOwnProfile }"
+      ></ViewKeys>
     </section>
     <EmptyCard v-else title="Keys" message="No keys have been added">
       <a id="nav-keys" class="profile__anchor"></a
@@ -215,21 +146,9 @@
       "
       class="profile__section"
     >
-      <a id="nav-access-groups" class="profile__anchor"></a>
-      <header class="profile__section-header">
-        <h2>Access Groups</h2>
-      </header>
-      <IconBlockList modifier="icon-block-list--multi-col">
-        <IconBlock
-          v-for="[group] in Object.entries(
-            accessInformation.mozilliansorg.values,
-          )"
-          :key="`group-${group}`"
-          icon="dino"
-        >
-          {{ group }}
-        </IconBlock>
-      </IconBlockList>
+      <ViewAccessGroups
+        v-bind="(accessInformation, userOnOwnProfile)"
+      ></ViewAccessGroups>
     </section>
     <EmptyCard
       v-else
@@ -242,30 +161,24 @@
 </template>
 
 <script>
-import AccountsMixin from '@/components/_mixins/AccountsMixin.vue';
-import Button from '@/components/ui/Button.vue';
-import Icon from '@/components/ui/Icon.vue';
-import IconBlock from '@/components/ui/IconBlock.vue';
-import IconBlockList from '@/components/ui/IconBlockList.vue';
-import Key from '@/components/ui/Key.vue';
-import Modal from '@/components/_functional/Modal.vue';
-import Person from '@/components/ui/Person.vue';
-import ShowMore from '@/components/_functional/ShowMore.vue';
-import Tag from '@/components/ui/Tag.vue';
 import Toast from '@/components/ui/Toast.vue';
-import Vouch from '@/components/ui/Vouch.vue';
+import EditAccounts from './edit/EditAccounts.vue';
 import EditContact from './edit/EditContact.vue';
+import EditKeys from './edit/EditKeys.vue';
 import EditLanguages from './edit/EditLanguages.vue';
 import EditPersonalInfo from '@/components/profile/edit/EditPersonalInfo.vue';
+import EditTags from './edit/EditTags.vue';
 import EmptyCard from '@/components/profile/view/EmptyCard.vue';
 import ProfileNav from './ProfileNav.vue';
-import ReportingStructure from './ReportingStructure.vue';
+import ViewAccounts from './view/ViewAccounts.vue';
 import ViewContact from './view/ViewContact.vue';
+import ViewKeys from './view/ViewKeys.vue';
 import ViewLanguages from './view/ViewLanguages.vue';
 import ViewPersonalInfo from './view/ViewPersonalInfo.vue';
+import ViewRelations from './view/ViewRelations.vue';
+import ViewTags from './view/ViewTags.vue';
 
 export default {
-  mixins: [AccountsMixin],
   name: 'Profile',
   props: {
     alternativeName: Object,
@@ -290,26 +203,22 @@ export default {
     primaryUsername: Object,
   },
   components: {
-    Button,
+    EditAccounts,
     EditContact,
+    EditKeys,
     EditLanguages,
     EditPersonalInfo,
+    EditTags,
     EmptyCard,
-    Icon,
-    IconBlock,
-    IconBlockList,
-    Key,
-    Modal,
-    Person,
     ProfileNav,
-    ReportingStructure,
-    ShowMore,
-    Tag,
     Toast,
+    ViewAccounts,
     ViewContact,
+    ViewKeys,
     ViewLanguages,
     ViewPersonalInfo,
-    Vouch,
+    ViewRelations,
+    ViewTags,
   },
   methods: {
     alphabetise(array) {
@@ -320,29 +229,14 @@ export default {
     },
   },
   computed: {
-    accounts() {
-      const wellKnown = Object.entries(this.uris.values || {})
-        .map((kv) => this.account(kv))
-        .filter((a) => a !== null && typeof a !== 'undefined');
-      const mozilla = wellKnown.filter(({ moz }) => moz);
-      const other = wellKnown.filter(({ moz }) => !moz);
-      return { mozilla, other };
-    },
     sections() {
       return {
         relations: this.staffInformation.staff,
         contact: true,
-        accounts: this.accounts.mozilla.length + this.accounts.other.length > 0,
+        accounts: this.uris.values !== undefined,
+        languages: this.languages.values !== undefined,
+        tags: this.tags.values !== undefined,
       };
-    },
-    tagsSorted() {
-      return this.alphabetise(Object.values(this.tags.values || {}));
-    },
-    languagesSorted() {
-      return (
-        this.languages.values &&
-        this.alphabetise(Object.values(this.languages.values))
-      );
     },
     userOnOwnProfile() {
       return (
@@ -478,16 +372,5 @@ export default {
 .profile__section-header > .privacy-setting button svg {
   order: -1;
   margin: 0 0.5em 0 0;
-}
-
-@media (min-width: 57.5em) {
-  .profile__external-accounts {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    grid-gap: 2em;
-  }
-  .profile__external-accounts h3 {
-    margin-top: 0; /* because grid item margins don't collapse */
-  }
 }
 </style>

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -321,7 +321,7 @@ export default {
   },
   computed: {
     accounts() {
-      const wellKnown = Object.entries(this.uris || {})
+      const wellKnown = Object.entries(this.uris.values || {})
         .map((kv) => this.account(kv))
         .filter((a) => a !== null && typeof a !== 'undefined');
       const mozilla = wellKnown.filter(({ moz }) => moz);

--- a/src/components/profile/edit/EditAccounts.vue
+++ b/src/components/profile/edit/EditAccounts.vue
@@ -16,40 +16,55 @@
         v-model="urisUpdated.display"
       />
     </header>
-    <div v-for="(username, type) in uris">
-      <select>
-        <option :value="type" :selected="type === 'EA#DISCOURSE'"
-          >Discourse</option
-        >
-        <option :value="type" :selected="type === 'EA#TWITTER'">Twitter</option>
-        >
-      </select>
-      <input type="username" v-bind="username" :value="username" />
+    <div
+      class="edit-contact__item"
+      v-for="(username, type, id) in uris"
+      :key="`account-item-${id}`"
+    >
+      <Select
+        class="options--chevron"
+        :label="`Account ${id} type`"
+        :id="`field-account-${id}-type`"
+        :options="selectableAccounts"
+        :value="type"
+      />
+      <input type="text" :value="username" />
+      <label class="edit-contact__set-as-contact"
+        ><input type="checkbox" /> Show in Contact Me button</label
+      >
+      <hr role="presentation" />
     </div>
     <br /><br />
-    <select v-model="newAccountType">
-      <option value="EA#DISCOURSE">Discourse</option>
-      <option value="EA#SLACK">Slack</option>
-      <option value="EA#IRC">IRC</option>
-    </select>
-    <input type="text" v-model="newAccountUsername" ref="inputUsername" />
-    <button
-      type="button"
-      @click="
-        if (newAccountUsername.length > 0) {
-          addAccount({ [newAccountType]: newAccountUsername });
-        } else {
-          $refs.inputUsername.focus();
-        }
-      "
-    >
-      Add account
-    </button>
+    <div class="edit-contact__item">
+      <Select
+        class="options--chevron"
+        label="New account type"
+        id="field-new-account-type"
+        :options="selectableAccounts"
+        v-model="newAccountType"
+      />
+      <input type="text" v-model="newAccountUsername" ref="inputUsername" />
+      <Button
+        class="edit-contact__add-more button--secondary button button--action"
+        type="button"
+        @click="
+          if (newAccountUsername.length > 0) {
+            addAccount({ [newAccountType]: newAccountUsername });
+          } else {
+            $refs.inputUsername.focus();
+          }
+        "
+        ><Icon id="plus" :width="16" :height="16" />Add Account</Button
+      >
+    </div>
   </EditMutationWrapper>
 </template>
 
 <script>
+import AccountsMixin from '@/components/_mixins/AccountsMixin.vue';
+import Icon from '@/components/ui/Icon.vue';
 import PrivacySetting from '@/components/profile/PrivacySetting.vue';
+import Select from '@/components/ui/Select.vue';
 import { displayLevelsFor, DISPLAY_LEVELS } from '@/assets/js/display-levels';
 import EditMutationWrapper from './EditMutationWrapper.vue';
 
@@ -59,14 +74,17 @@ export default {
     initialValues: Object,
     editVariables: Object,
   },
+  mixins: [AccountsMixin],
   components: {
     EditMutationWrapper,
+    Icon,
     PrivacySetting,
+    Select,
   },
   methods: {
     displayLevelsFor,
     addAccount(uri) {
-      this.uris = { ...this.uris, uri };
+      this.uris = { ...this.uris, ...uri };
       this.newAccountUsername = '';
     },
     formatAsKeyValues(item) {
@@ -90,7 +108,8 @@ export default {
   },
   data() {
     return {
-      newAccount: '',
+      newAccountUsername: '',
+      newAccountType: '',
       uris: this.initialValues.uris.values,
       urisUpdated: {
         values: Object.entries(this.initialValues.uris.values).map(

--- a/src/components/profile/edit/EditAccounts.vue
+++ b/src/components/profile/edit/EditAccounts.vue
@@ -1,0 +1,106 @@
+<template>
+  <EditMutationWrapper
+    :editVariables="{
+      accounts: urisUpdated,
+    }"
+    :initialValues="initialValues"
+    formName="Edit accounts"
+  >
+    <header class="profile__section-header" ref="header" tabindex="-1">
+      <h2>Accounts</h2>
+      <PrivacySetting
+        label="Accounts privacy levels"
+        id="section-accounts-privacy"
+        :profileField="urisUpdated"
+        :collapsedShowLabel="true"
+        v-model="urisUpdated.display"
+      />
+    </header>
+    <div v-for="(username, type) in uris">
+      <select>
+        <option :value="type" :selected="type === 'EA#DISCOURSE'"
+          >Discourse</option
+        >
+        <option :value="type" :selected="type === 'EA#TWITTER'">Twitter</option>
+        >
+      </select>
+      <input type="username" v-bind="username" :value="username" />
+    </div>
+    <br /><br />
+    <select v-model="newAccountType">
+      <option value="EA#DISCOURSE">Discourse</option>
+      <option value="EA#SLACK">Slack</option>
+      <option value="EA#IRC">IRC</option>
+    </select>
+    <input type="text" v-model="newAccountUsername" ref="inputUsername" />
+    <button
+      type="button"
+      @click="
+        if (newAccountUsername.length > 0) {
+          addAccount({ [newAccountType]: newAccountUsername });
+        } else {
+          $refs.inputUsername.focus();
+        }
+      "
+    >
+      Add account
+    </button>
+  </EditMutationWrapper>
+</template>
+
+<script>
+import PrivacySetting from '@/components/profile/PrivacySetting.vue';
+import { displayLevelsFor, DISPLAY_LEVELS } from '@/assets/js/display-levels';
+import EditMutationWrapper from './EditMutationWrapper.vue';
+
+export default {
+  name: 'EditAccounts',
+  props: {
+    initialValues: Object,
+    editVariables: Object,
+  },
+  components: {
+    EditMutationWrapper,
+    PrivacySetting,
+  },
+  methods: {
+    displayLevelsFor,
+    addAccount(uri) {
+      this.uris = { ...this.uris, uri };
+      this.newAccountUsername = '';
+    },
+    formatAsKeyValues(item) {
+      const [k, v] = item;
+
+      return {
+        k,
+        v,
+      };
+    },
+  },
+  watch: {
+    uris() {
+      this.urisUpdated.values = Object.entries(this.uris).map(
+        this.formatAsKeyValues,
+      );
+    },
+  },
+  mounted() {
+    this.$refs.header.focus();
+  },
+  data() {
+    return {
+      newAccount: '',
+      uris: this.initialValues.uris.values,
+      urisUpdated: {
+        values: Object.entries(this.initialValues.uris.values).map(
+          this.formatAsKeyValues,
+        ),
+        display:
+          this.initialValues.uris.metadata.display ||
+          DISPLAY_LEVELS.private.value,
+      },
+    };
+  },
+};
+</script>

--- a/src/components/profile/edit/EditKeys.vue
+++ b/src/components/profile/edit/EditKeys.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <header class="profile__section-header">
+      <h2>Keys</h2>
+    </header>
+    <p>This section cannot yet be edited in DinoPark</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'EditKeys',
+};
+</script>

--- a/src/components/profile/edit/EditLanguages.vue
+++ b/src/components/profile/edit/EditLanguages.vue
@@ -97,7 +97,8 @@ export default {
           this.formatAsKeyValues,
         ),
         display:
-          this.initialValues.languages.display || DISPLAY_LEVELS.public.value,
+          this.initialValues.languages.metadata.display ||
+          DISPLAY_LEVELS.public.value,
       },
     };
   },

--- a/src/components/profile/edit/EditMutationWrapper.vue
+++ b/src/components/profile/edit/EditMutationWrapper.vue
@@ -45,7 +45,7 @@ export default {
   },
   methods: {
     handleError() {
-      this.$emit('toast', {
+      this.$parent.$emit('toast', {
         content: 'A problem occured, please try again later.',
       });
     },
@@ -76,7 +76,7 @@ export default {
       });
 
       this.$emit('toggle-edit-mode');
-      this.$emit('toast', {
+      this.$parent.$emit('toast', {
         content: 'Your changes have been saved. Thank you.',
       });
     },

--- a/src/components/profile/edit/EditPersonalInfo.vue
+++ b/src/components/profile/edit/EditPersonalInfo.vue
@@ -1,6 +1,7 @@
 <template>
   <EditMutationWrapper
     :editVariables="{
+      picture,
       primaryUsername,
       firstName,
       lastName,
@@ -191,7 +192,6 @@ import EditPictureModal from './EditPictureModal.vue';
 export default {
   name: 'EditPersonalInfo',
   props: {
-    picture: Object,
     staffInformation: Object,
     initialValues: Object,
   },

--- a/src/components/profile/edit/EditPictureModal.vue
+++ b/src/components/profile/edit/EditPictureModal.vue
@@ -27,12 +27,12 @@
     </div>
 
     <div class="edit-picture-modal__picture">
-      <Crop v-if="imgSrc" :src="imgSrc" />
+      <Crop v-if="imgSrc" :src="imgSrc" ref="crop" />
       <UserPicture
         v-else
         :picture="picture.value"
         :username="username.value"
-        :size="230"
+        :size="264"
         :isStaff="staffInformation.staff.value"
       ></UserPicture>
     </div>
@@ -66,8 +66,9 @@
         type="button"
         class="button button--primary"
         :disabled="!privacyAgreed"
+        @click="selectCrop()"
       >
-        Save
+        Select
       </button>
     </div>
   </Modal>
@@ -94,6 +95,10 @@ export default {
         this.imgSrc = fr.result;
       };
       fr.readAsDataURL(event.target.files[0]);
+    },
+    selectCrop() {
+      this.picture.value = this.$refs.crop.cropper.toDataURL();
+      this.$emit('close');
     },
   },
 };

--- a/src/components/profile/edit/EditTags.vue
+++ b/src/components/profile/edit/EditTags.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    <header class="profile__section-header">
+      <h2>Tags</h2>
+    </header>
+    <p>This section cannot yet be edited in DinoPark</p>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'EditTags',
+};
+</script>

--- a/src/components/profile/view/ViewAccessGroups.vue
+++ b/src/components/profile/view/ViewAccessGroups.vue
@@ -1,0 +1,35 @@
+<template>
+  <div>
+    <header class="profile__section-header">
+      <h2>Access Groups</h2>
+    </header>
+    <a id="nav-access-groups" class="profile__anchor"></a>
+    <IconBlockList modifier="icon-block-list--multi-col">
+      <IconBlock
+        v-for="[group] in Object.entries(
+          accessInformation.mozilliansorg.values,
+        )"
+        :key="`group-${group}`"
+        icon="dino"
+      >
+        {{ group }}
+      </IconBlock>
+    </IconBlockList>
+  </div>
+</template>
+
+<script>
+import IconBlock from '@/components/ui/IconBlock.vue';
+import IconBlockList from '@/components/ui/IconBlockList.vue';
+
+export default {
+  name: 'ViewAccessGroups',
+  props: {
+    accessInformation: Object,
+  },
+  components: {
+    IconBlock,
+    IconBlockList,
+  },
+};
+</script>

--- a/src/components/profile/view/ViewAccounts.vue
+++ b/src/components/profile/view/ViewAccounts.vue
@@ -2,6 +2,20 @@
   <div>
     <header class="profile__section-header">
       <h2>Accounts</h2>
+      <button
+        class="profile__edit-button"
+        v-if="userOnOwnProfile"
+        @click="
+          $router.push({
+            name: 'Edit Profile',
+            query: {
+              section: 'accounts',
+            },
+          })
+        "
+      >
+        <img src="@/assets/images/icon-pencil.svg" alt="Edit accounts" />
+      </button>
     </header>
     <div class="profile__external-accounts">
       <div v-if="accounts.mozilla.length">
@@ -47,6 +61,7 @@ export default {
   name: 'ViewAccounts',
   props: {
     uris: Object,
+    userOnOwnProfile: Boolean,
   },
   mixins: [AccountsMixin],
   components: {

--- a/src/components/profile/view/ViewAccounts.vue
+++ b/src/components/profile/view/ViewAccounts.vue
@@ -1,0 +1,80 @@
+<template>
+  <div>
+    <header class="profile__section-header">
+      <h2>Accounts</h2>
+    </header>
+    <div class="profile__external-accounts">
+      <div v-if="accounts.mozilla.length">
+        <h3>Mozilla</h3>
+        <IconBlockList>
+          <IconBlock
+            v-for="(acc, index) in accounts.mozilla"
+            :key="`acc-moz-${index}`"
+            :heading="acc.text"
+            :icon="acc.icon"
+          >
+            <a :href="acc.value" target="_blank" rel="noreferrer noopener">{{
+              acc.value
+            }}</a>
+          </IconBlock>
+        </IconBlockList>
+      </div>
+      <div v-if="accounts.other.length">
+        <h3>Elsewhere</h3>
+        <IconBlockList>
+          <IconBlock
+            v-for="(acc, index) in accounts.other"
+            :key="`acc-other-${index}`"
+            :heading="acc.text"
+            :icon="acc.icon"
+          >
+            <a :href="acc.value" target="_blank" rel="noreferrer noopener">{{
+              acc.value
+            }}</a>
+          </IconBlock>
+        </IconBlockList>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import AccountsMixin from '@/components/_mixins/AccountsMixin.vue';
+import IconBlock from '@/components/ui/IconBlock.vue';
+import IconBlockList from '@/components/ui/IconBlockList.vue';
+
+export default {
+  name: 'ViewAccounts',
+  props: {
+    uris: Object,
+  },
+  mixins: [AccountsMixin],
+  components: {
+    IconBlock,
+    IconBlockList,
+  },
+  computed: {
+    accounts() {
+      const wellKnown = Object.entries(this.uris.values || {})
+        .map((kv) => this.account(kv))
+        .filter((a) => a !== null && typeof a !== 'undefined');
+      const mozilla = wellKnown.filter(({ moz }) => moz);
+      const other = wellKnown.filter(({ moz }) => !moz);
+      return { mozilla, other };
+    },
+  },
+};
+</script>
+
+<style>
+@media (min-width: 57.5em) {
+  .profile__external-accounts {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-gap: 2em;
+  }
+  .profile__external-accounts h3 {
+    margin-top: 0; /* because grid item margins don't collapse */
+  }
+}
+</style>

--- a/src/components/profile/view/ViewKeys.vue
+++ b/src/components/profile/view/ViewKeys.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    <header class="profile__section-header">
+      <h2>Keys</h2>
+    </header>
+    <template
+      v-if="pgpPublicKeys && Object.keys(pgpPublicKeys.values).length > 0"
+    >
+      <h4 class="visually-hidden">PGP</h4>
+      <Key
+        v-for="[key, value] in Object.entries(pgpPublicKeys.values)"
+        type="PGP"
+        :title="key"
+        :content="value"
+        :key="`pgp-${key}`"
+      />
+    </template>
+    <template
+      v-if="sshPublicKeys && Object.keys(sshPublicKeys.values).length > 0"
+    >
+      <h4 class="visually-hidden">SSH</h4>
+      <Key
+        v-for="[key, value] in Object.entries(sshPublicKeys.values)"
+        type="SSH"
+        :title="key"
+        :content="value"
+        :key="`ssh-${key}`"
+      />
+    </template>
+  </div>
+</template>
+
+<script>
+import Key from '@/components/ui/Key.vue';
+
+export default {
+  name: 'ViewKeys',
+  props: {
+    pgpPublicKeys: Object,
+    sshPublicKeys: Object,
+  },
+  components: {
+    Key,
+  },
+};
+</script>

--- a/src/components/profile/view/ViewRelations.vue
+++ b/src/components/profile/view/ViewRelations.vue
@@ -1,0 +1,36 @@
+<template>
+  <div>
+    <header class="profile__section-header">
+      <h2>Colleagues</h2>
+      <RouterLink
+        :to="{
+          name: 'OrgchartHighlight',
+          params: { username: primaryUsername.value },
+        }"
+        class="button button--secondary button--small"
+      >
+        <Icon id="org-chart" :width="16" :height="16" />
+        Org Chart
+        <Icon id="chevron-right" :width="18" :height="18" />
+      </RouterLink>
+    </header>
+    <ReportingStructure :username="primaryUsername.value"> </ReportingStructure>
+  </div>
+</template>
+
+<script>
+import Icon from '@/components/ui/Icon.vue';
+import ReportingStructure from '@/components/profile/ReportingStructure.vue';
+
+export default {
+  name: 'ViewLanguages',
+  props: {
+    primaryUsername: Object,
+    userOnOwnProfile: Boolean,
+  },
+  components: {
+    Icon,
+    ReportingStructure,
+  },
+};
+</script>

--- a/src/components/profile/view/ViewTags.vue
+++ b/src/components/profile/view/ViewTags.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <header class="profile__section-header">
-      <h2>Languages</h2>
+      <h2>Tags</h2>
       <button
         class="profile__edit-button"
         v-if="userOnOwnProfile"
@@ -9,20 +9,15 @@
           $router.push({
             name: 'Edit Profile',
             query: {
-              section: 'languages',
+              section: 'tags',
             },
           })
         "
       >
-        <img src="@/assets/images/icon-pencil.svg" alt="Edit languages" />
+        <img src="@/assets/images/icon-pencil.svg" alt="Edit tags" />
       </button>
     </header>
-    <Tag
-      v-for="(language, index) in languages.values"
-      :tag="language"
-      :key="`language-${index}`"
-    >
-    </Tag>
+    <Tag v-for="(tag, index) in tags.values" :tag="tag" :key="`tag-${index}`" />
   </div>
 </template>
 
@@ -30,9 +25,9 @@
 import Tag from '@/components/ui/Tag.vue';
 
 export default {
-  name: 'ViewLanguages',
+  name: 'ViewTags',
   props: {
-    languages: Object,
+    tags: Object,
     userOnOwnProfile: Boolean,
   },
   components: {

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -153,7 +153,6 @@ export default {
   border: 1px solid var(--blue-60);
 }
 .options .options__list {
-  max-height: 25em;
   padding: 0;
   background-color: var(--white);
   box-shadow: 0 0.125em 0.25em 0.125em rgba(210, 210, 210, 0.5);
@@ -192,6 +191,8 @@ export default {
 .options__list ul {
   margin: 0;
   padding-left: 0;
+  max-height: 25em;
+  overflow: auto;
 }
 .options__list > a {
   padding: 1em;

--- a/src/components/ui/UserPicture.vue
+++ b/src/components/ui/UserPicture.vue
@@ -63,7 +63,11 @@ export default {
       if (this.picture.startsWith('data:')) {
         return this.picture;
       }
-      if (this.picture === null || this.picture === '/beta/img/user-demo.png') {
+      if (
+        this.picture === null ||
+        this.picture === '' ||
+        this.picture === '/beta/img/user-demo.png'
+      ) {
         let hash;
         if (window.crypto && window.crypto.subtle) {
           hash = await sha256(this.username);

--- a/src/components/ui/UserPicture.vue
+++ b/src/components/ui/UserPicture.vue
@@ -60,6 +60,9 @@ export default {
   },
   methods: {
     async updateUserPicture() {
+      if (this.picture.startsWith('data:')) {
+        return this.picture;
+      }
       if (this.picture === null || this.picture === '/beta/img/user-demo.png') {
         let hash;
         if (window.crypto && window.crypto.subtle) {
@@ -74,7 +77,7 @@ export default {
         });
         return `data:image/svg+xml;base64,${identicon.toString()}`;
       }
-      return `/beta/avatar/${this.slot}/${this.picture}`;
+      return `${this.picture}?size=${this.slot}`;
     },
     decidePictureCategory(size) {
       if (size <= 40) {

--- a/src/queries/profile.js
+++ b/src/queries/profile.js
@@ -309,6 +309,12 @@ const DISPLAY_PROFILE = gql`
           display
         }
       }
+      uris {
+        values
+        metadata {
+          display
+        }
+      }
     }
   }
 `;

--- a/src/queries/profile.js
+++ b/src/queries/profile.js
@@ -87,6 +87,7 @@ const MUTATE_PROFILE = gql`
     $funTitle: StringWithDisplay
     $lastName: StringWithDisplay
     $location: StringWithDisplay
+    $picture: StringWithDisplay
     $pronouns: StringWithDisplay
     $timezone: StringWithDisplay
     $languages: KeyValuesWithDisplay
@@ -100,6 +101,7 @@ const MUTATE_PROFILE = gql`
         lastName: $lastName
         location: $location
         pronouns: $pronouns
+        picture: $picture
         timezone: $timezone
         languages: $languages
       }
@@ -135,6 +137,12 @@ const MUTATE_PROFILE = gql`
         }
       }
       location {
+        value
+        metadata {
+          display
+        }
+      }
+      picture {
         value
         metadata {
           display

--- a/src/queries/profile.js
+++ b/src/queries/profile.js
@@ -160,6 +160,12 @@ const MUTATE_PROFILE = gql`
           display
         }
       }
+      uris {
+        values
+        metadata {
+          display
+        }
+      }
       languages {
         values
         metadata {


### PR DESCRIPTION
Changes: 

* I've removed all remaining card content from the `Profile` component and moved to `Edit*`/`View*` components
* `AccountsMixin` now also exports an object as computed property that is compatible with our custom `Select`
* the `EditAccounts` component is mostly styled as per designs, adding an account from a specific type works

Known issues:

* In the `<Select>` for account types, we probably only want to show the three accounts we agreed on (Discourse IRC, Slack), so maybe we need to `filter` for those (or remove them from mixin for now?)
* On the `EditAccounts`, we don't yet split between Mozilla and Elsewhere accounts
* Setting the same account type twice is possible (but weird), because of how we use keys they will overwrite the old one. Maybe the 'add account' select should no longer show options for accounts that are already set?