### PR TITLE
Update accounts

### DIFF
--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -39,6 +39,8 @@ const EXTERNAL_ACCOUNTS = {
   'EA#WEBSITE': { moz: false, text: 'Website URL', icon: 'website' },
   'EA#JABBER': { moz: false, text: 'XMPP/Jabber', icon: 'jabber' },
   'EA#YAHOO': { moz: false, text: 'Yahoo! Messenger', icon: 'yahoo' },
+  'EA#IRC': { moz: false, text: 'IRC', icon: 'dino' },
+  'EA#SLACK': { moz: false, text: 'Slack', icon: 'dino' },
 };
 
 export default {

--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -10,7 +10,12 @@ const EXTERNAL_ACCOUNTS = {
   'EA#MDN': { moz: true, text: 'MDN', icon: 'mdn' },
   'EA#MASTODON': { moz: false, text: 'Mastodon', icon: 'mastodon' },
   'EA#AMO': { moz: true, text: 'Mozilla Add-ons', icon: 'amo' },
-  'EA#DISCOURSE': { moz: true, text: 'Mozilla Discourse', icon: 'discourse' },
+  'EA#DISCOURSE': {
+    moz: true,
+    text: 'Mozilla Discourse',
+    icon: 'discourse',
+    uri: 'https://discourse.mozilla.org/u/@@@',
+  },
   'EA#MOZPHAB': { moz: true, text: 'Mozilla Phabricator', icon: 'mozphab' },
   'EA#MOZILLAPONTOON': {
     moz: true,
@@ -35,7 +40,12 @@ const EXTERNAL_ACCOUNTS = {
   'EA#SLIDESHARE': { moz: false, text: 'SlideShare', icon: 'slideshare' },
   'EA#TELEGRAM': { moz: false, text: 'Telegram', icon: 'telegram' },
   'EA#TRANSIFEX': { moz: false, text: 'Transifex', icon: 'transifex' },
-  'EA#TWITTER': { moz: false, text: 'Twitter', icon: 'twitter' },
+  'EA#TWITTER': {
+    moz: false,
+    text: 'Twitter',
+    icon: 'twitter',
+    uri: 'https://twitter.com/@@@',
+  },
   'EA#WEBSITE': { moz: false, text: 'Website URL', icon: 'website' },
   'EA#JABBER': { moz: false, text: 'XMPP/Jabber', icon: 'jabber' },
   'EA#YAHOO': { moz: false, text: 'Yahoo! Messenger', icon: 'yahoo' },
@@ -47,12 +57,19 @@ export default {
   methods: {
     account([key, value]) {
       const { moz, text, icon } = EXTERNAL_ACCOUNTS[key] || {};
+      let { uri } = EXTERNAL_ACCOUNTS[key] || null;
+
+      if (uri) {
+        uri = uri.replace(/@@@/g, value);
+      }
+
       if (text && icon && typeof moz === 'boolean') {
         return {
           moz,
           text,
           icon,
           value,
+          uri,
         };
       }
       return null;

--- a/src/components/profile/edit/EditAccounts.vue
+++ b/src/components/profile/edit/EditAccounts.vue
@@ -1,7 +1,7 @@
 <template>
   <EditMutationWrapper
     :editVariables="{
-      accounts: urisUpdated,
+      uris: urisUpdated,
     }"
     :initialValues="initialValues"
     formName="Edit accounts"
@@ -16,27 +16,52 @@
         v-model="urisUpdated.display"
       />
     </header>
-    <div
-      class="edit-contact__item"
-      v-for="(username, type, id) in uris"
-      :key="`account-item-${id}`"
-    >
+    <div class="edit-contact__item">
       <Select
         class="options--chevron"
-        :label="`Account ${id} type`"
-        :id="`field-account-${id}-type`"
+        :label="`Account 1 type`"
+        :id="`field-account-1-type`"
         :options="selectableAccounts"
-        :value="type"
+        value="EA#SLACK"
         :disabled="true"
       />
-      <input type="text" :value="username" disabled />
+      <input type="text" v-model="uris['EA#SLACK']" />
       <label class="edit-contact__set-as-contact"
         ><input type="checkbox" /> Show in Contact Me button</label
       >
       <hr role="presentation" />
     </div>
-    <br /><br />
     <div class="edit-contact__item">
+      <Select
+        class="options--chevron"
+        :label="`Account 2 type`"
+        :id="`field-account-2-type`"
+        :options="selectableAccounts"
+        value="EA#IRC"
+        :disabled="true"
+      />
+      <input type="text" v-model="uris['EA#IRC']" />
+      <label class="edit-contact__set-as-contact"
+        ><input type="checkbox" /> Show in Contact Me button</label
+      >
+      <hr role="presentation" />
+    </div>
+    <div class="edit-contact__item">
+      <Select
+        class="options--chevron"
+        :label="`Account 3 type`"
+        :id="`field-account-3-type`"
+        :options="selectableAccounts"
+        value="EA#DISCOURSE"
+        :disabled="true"
+      />
+      <input type="text" v-model="uris['EA#DISCOURSE']" />
+      <label class="edit-contact__set-as-contact"
+        ><input type="checkbox" /> Show in Contact Me button</label
+      >
+      <hr role="presentation" />
+    </div>
+    <div class="edit-contact__item" v-show="false">
       <Select
         class="options--chevron"
         label="New account type"
@@ -98,10 +123,13 @@ export default {
     },
   },
   watch: {
-    uris() {
-      this.urisUpdated.values = Object.entries(this.uris).map(
-        this.formatAsKeyValues,
-      );
+    uris: {
+      handler() {
+        this.urisUpdated.values = Object.entries(this.uris).map(
+          this.formatAsKeyValues,
+        );
+      },
+      deep: true,
     },
   },
   mounted() {

--- a/src/components/profile/view/ViewAccounts.vue
+++ b/src/components/profile/view/ViewAccounts.vue
@@ -27,9 +27,14 @@
             :heading="acc.text"
             :icon="acc.icon"
           >
-            <a :href="acc.value" target="_blank" rel="noreferrer noopener">{{
-              acc.value
-            }}</a>
+            <a
+              v-if="acc.uri"
+              :href="acc.uri"
+              target="_blank"
+              rel="noreferrer noopener"
+              >{{ acc.value }}</a
+            >
+            <template v-else>{{ acc.value }}</template>
           </IconBlock>
         </IconBlockList>
       </div>
@@ -42,9 +47,14 @@
             :heading="acc.text"
             :icon="acc.icon"
           >
-            <a :href="acc.value" target="_blank" rel="noreferrer noopener">{{
-              acc.value
-            }}</a>
+            <a
+              v-if="acc.uri"
+              :href="acc.uri"
+              target="_blank"
+              rel="noreferrer noopener"
+              >{{ acc.value }}</a
+            >
+            <template v-else>{{ acc.value }}</template>
           </IconBlock>
         </IconBlockList>
       </div>

--- a/src/queries/profile.js
+++ b/src/queries/profile.js
@@ -92,6 +92,7 @@ const MUTATE_PROFILE = gql`
     $pronouns: StringWithDisplay
     $timezone: StringWithDisplay
     $languages: KeyValuesWithDisplay
+    $uris: KeyValuesWithDisplay
   ) {
     profile(
       update: {
@@ -106,6 +107,7 @@ const MUTATE_PROFILE = gql`
         picture: $picture
         timezone: $timezone
         languages: $languages
+        uris: $uris
       }
     ) {
       primaryUsername {


### PR DESCRIPTION
* Ensure accounts are saved
* Limit to 3 hard coded account types; remove ‘Add new account’, as those three are the only editable ones
* Added 'uri' to `EXTERNAL_ACCOUNTS` object, to set URL for accounts that we can link to, we can use this in the front-end to display links to URLs