### PR TITLE
Improve dropdown (fixes DP-1076, DP-1137, DP-1142, DP-1143)

### DIFF
--- a/src/components/profile/PrivacySetting.vue
+++ b/src/components/profile/PrivacySetting.vue
@@ -6,6 +6,7 @@
     v-bind="privacySettings"
     v-model="profileFieldObject.display"
     :options="displayLevelsFor(profileFieldName)"
+    :disabled="disabled"
     @input="$emit('input', $event)"
   >
     <template v-slot:extra-content
@@ -33,6 +34,7 @@ export default {
       type: Boolean,
       default: false,
     },
+    disabled: Boolean,
   },
   methods: {
     displayLevelsFor,

--- a/src/components/profile/edit/EditPersonalInfo.vue
+++ b/src/components/profile/edit/EditPersonalInfo.vue
@@ -57,6 +57,7 @@
         profileFieldName="primaryUsername"
         :profileFieldObject="primaryUsername"
         v-model="primaryUsername.display"
+        :disabled="true"
       />
 
       <hr role="presentation" />

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -1,5 +1,8 @@
 <template>
-  <div :class="'options' + (position ? ' ' + `options--${position}` : '')">
+  <div
+    :class="'options' + (position ? ' ' + `options--${position}` : '')"
+    ref="options"
+  >
     <button
       @click="toggleOptions"
       @keydown.up.down.prevent="toggleOptions"
@@ -103,6 +106,9 @@ export default {
     closeList() {
       this.open = false;
       this.focusToggle();
+
+      // document.removeEventListener('click', this.handleDocumentClick);
+      // document.removeEventListener('touchstart', this.handleDocumentClick);
     },
     focusToggle() {
       const optionToggle = this.$refs[`optionToggle-${this.id}`];
@@ -111,6 +117,30 @@ export default {
         this.$nextTick(() => {
           optionToggle.focus();
         });
+      }
+    },
+    handleDocumentClick(event) {
+      const expandedEl = this.$refs.options;
+
+      // closes overflow content if clicked anywhere, except the
+      // overflowing content itself
+      if (
+        event.target !== expandedEl &&
+        expandedEl.contains(event.target) === false &&
+        this.open === true
+      ) {
+        this.toggleOptions();
+      }
+    },
+  },
+  watch: {
+    open() {
+      if (this.open) {
+        document.addEventListener('click', this.handleDocumentClick);
+        document.addEventListener('touchstart', this.handleDocumentClick);
+      } else {
+        document.removeEventListener('click', this.handleDocumentClick);
+        document.removeEventListener('touchstart', this.handleDocumentClick);
       }
     },
   },

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -152,10 +152,12 @@ export default {
   padding-right: 3em;
 }
 .options .options__toggle[disabled] {
-  padding-right: 0.9em;
   background-image: none;
   cursor: not-allowed;
   color: var(--black);
+}
+.options--chevron .options__toggle[disabled] {
+  padding-right: 0.9em;
 }
 .options__toggle[aria-expanded='true'] {
   border: 1px solid var(--blue-60);

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="options">
+  <div :class="'options' + (position ? ' ' + `options--${position}` : '')">
     <button
       @click="toggleOptions"
       @keydown.up.down.prevent="toggleOptions"
@@ -117,7 +117,22 @@ export default {
   data() {
     return {
       open: false,
+      position: '',
     };
+  },
+  mounted() {
+    const optionToggle = this.$refs[`optionToggle-${this.id}`];
+    const { left: spaceOnLeft, right } = optionToggle.getBoundingClientRect();
+    const spaceOnRight =
+      document.scrollingElement.getBoundingClientRect().width - right;
+
+    if (spaceOnRight > 300) {
+      this.position = 'right';
+    } else if (spaceOnLeft > 300) {
+      this.position = 'left';
+    } else {
+      this.position = '';
+    }
   },
   computed: {
     selectedOption() {
@@ -197,6 +212,24 @@ export default {
   box-shadow: 0 0 0.25em 0 var(--gray-30);
   border: inherit;
   border-radius: inherit;
+}
+.options--left .options__list {
+  transform: translateX(calc(-100% + 5em));
+}
+.options--left .options__list::before {
+  left: auto;
+  right: 1em;
+}
+.options--right .options__list {
+  transform: translateX(calc(-1.5em));
+}
+.options--right .options__list::before {
+  left: 2em;
+}
+@media (min-width: 57.5em) {
+  .options--left .options__list {
+    transform: translateX(calc(-100% + 2.5em));
+  }
 }
 .options__list ul {
   margin: 0;

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -106,9 +106,6 @@ export default {
     closeList() {
       this.open = false;
       this.focusToggle();
-
-      // document.removeEventListener('click', this.handleDocumentClick);
-      // document.removeEventListener('touchstart', this.handleDocumentClick);
     },
     focusToggle() {
       const optionToggle = this.$refs[`optionToggle-${this.id}`];


### PR DESCRIPTION
* Make username privacy settings non-editable (DP-1142)
* Make a guess about where the custom select should show (left, right, center), kept this fairly simple to cover most use cases (DP-1076)