### PR TITLE
Fix display of cards that have no data

### DIFF
--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -97,9 +97,16 @@
       ></EditAccounts>
       <ViewAccounts v-else v-bind="{ uris, userOnOwnProfile }"></ViewAccounts>
     </section>
-    <EmptyCard v-else title="Accounts" message="No accounts have been added"
-      ><a id="nav-accounts" class="profile__anchor"></a
-    ></EmptyCard>
+    <EmptyCard v-else title="Accounts" message="No accounts have been added">
+      <a id="nav-accounts" class="profile__anchor"></a>
+      <template v-slot="header">
+        <EditButton
+          v-if="userOnOwnProfile"
+          section="accounts"
+          sectionId="accounts"
+        ></EditButton>
+      </template>
+    </EmptyCard>
     <section
       v-if="sections.languages"
       :class="
@@ -123,8 +130,15 @@
       ></ViewLanguages>
     </section>
     <EmptyCard v-else title="Languages" message="No languages have been added">
-      <a id="nav-languages" class="profile__anchor"></a
-    ></EmptyCard>
+      <a id="nav-languages" class="profile__anchor"></a>
+      <template v-slot="header">
+        <EditButton
+          v-if="userOnOwnProfile"
+          section="languages"
+          sectionId="languages"
+        ></EditButton>
+      </template>
+    </EmptyCard>
     <section
       v-if="sections.tags"
       :class="
@@ -137,8 +151,15 @@
       <ViewTags v-else v-bind="{ tags, userOnOwnProfile }"></ViewTags>
     </section>
     <EmptyCard v-else title="Tags" message="No tags have been added">
-      <a id="nav-tags" class="profile__anchor"></a
-    ></EmptyCard>
+      <a id="nav-tags" class="profile__anchor"></a>
+      <template v-slot="header">
+        <EditButton
+          v-if="userOnOwnProfile"
+          section="tags"
+          sectionId="tags"
+        ></EditButton>
+      </template>
+    </EmptyCard>
     <section class="profile__section" v-if="pgpPublicKeys || sshPublicKeys">
       <EditKeys v-if="this.editing === 'keys'"> </EditKeys>
       <ViewKeys
@@ -170,6 +191,7 @@
 
 <script>
 import Toast from '@/components/ui/Toast.vue';
+import EditButton from '@/components/profile/edit/EditButton.vue';
 import EditAccounts from './edit/EditAccounts.vue';
 import EditContact from './edit/EditContact.vue';
 import EditKeys from './edit/EditKeys.vue';
@@ -213,6 +235,7 @@ export default {
   },
   components: {
     EditAccounts,
+    EditButton,
     EditContact,
     EditKeys,
     EditLanguages,

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -265,9 +265,22 @@ export default {
       return {
         relations: this.staffInformation.staff,
         contact: true,
-        accounts: this.uris.values !== null,
-        languages: this.languages.values !== null,
-        tags: this.tags.values !== null,
+        accounts:
+          this.userOnOwnProfile ||
+          (this.uris.values &&
+            Object.entries(this.uris.values).length > 0 &&
+            true) ||
+          false,
+        languages:
+          (this.languages.values &&
+            Object.entries(this.languages.values).length > 0 &&
+            true) ||
+          false,
+        tags:
+          (this.tags.values &&
+            Object.entries(this.tags.values).length > 0 &&
+            true) ||
+          false,
       };
     },
     userOnOwnProfile() {

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -152,13 +152,7 @@
     </section>
     <EmptyCard v-else title="Tags" message="No tags have been added">
       <a id="nav-tags" class="profile__anchor"></a>
-      <template v-slot:header>
-        <EditButton
-          v-if="userOnOwnProfile"
-          section="tags"
-          sectionId="tags"
-        ></EditButton>
-      </template>
+      <template v-slot:header> </template>
     </EmptyCard>
     <section class="profile__section" v-if="pgpPublicKeys || sshPublicKeys">
       <EditKeys v-if="this.editing === 'keys'"> </EditKeys>

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -152,7 +152,6 @@
     </section>
     <EmptyCard v-else title="Tags" message="No tags have been added">
       <a id="nav-tags" class="profile__anchor"></a>
-      <template v-slot:header> </template>
     </EmptyCard>
     <section class="profile__section" v-if="pgpPublicKeys || sshPublicKeys">
       <EditKeys v-if="this.editing === 'keys'"> </EditKeys>

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -266,7 +266,6 @@ export default {
         relations: this.staffInformation.staff,
         contact: true,
         accounts:
-          this.userOnOwnProfile ||
           (this.uris.values &&
             Object.entries(this.uris.values).length > 0 &&
             true) ||

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -242,9 +242,9 @@ export default {
       return {
         relations: this.staffInformation.staff,
         contact: true,
-        accounts: this.uris.values !== undefined,
-        languages: this.languages.values !== undefined,
-        tags: this.tags.values !== undefined,
+        accounts: this.uris.values !== null,
+        languages: this.languages.values !== null,
+        tags: this.tags.values !== null,
       };
     },
     userOnOwnProfile() {

--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -99,7 +99,7 @@
     </section>
     <EmptyCard v-else title="Accounts" message="No accounts have been added">
       <a id="nav-accounts" class="profile__anchor"></a>
-      <template v-slot="header">
+      <template v-slot:header>
         <EditButton
           v-if="userOnOwnProfile"
           section="accounts"
@@ -131,7 +131,7 @@
     </section>
     <EmptyCard v-else title="Languages" message="No languages have been added">
       <a id="nav-languages" class="profile__anchor"></a>
-      <template v-slot="header">
+      <template v-slot:header>
         <EditButton
           v-if="userOnOwnProfile"
           section="languages"
@@ -152,7 +152,7 @@
     </section>
     <EmptyCard v-else title="Tags" message="No tags have been added">
       <a id="nav-tags" class="profile__anchor"></a>
-      <template v-slot="header">
+      <template v-slot:header>
         <EditButton
           v-if="userOnOwnProfile"
           section="tags"

--- a/src/components/profile/edit/EditButton.vue
+++ b/src/components/profile/edit/EditButton.vue
@@ -1,6 +1,6 @@
 <template>
   <RouterLink
-    class="profile__edit-button"
+    class="edit-button"
     :to="{
       name: 'Edit Profile',
       query: {
@@ -8,16 +8,43 @@
       },
     }"
   >
-    <img src="@/assets/images/icon-pencil.svg" :alt="`Edit ${section}`" />
+    <Icon id="pencil" :width="20" :height="20"></Icon>
+    <span class="visually-hidden">Edit {{ section }}</span>
   </RouterLink>
 </template>
 
 <script>
+import Icon from '@/components/ui/Icon.vue';
+
 export default {
   name: 'EditButton',
   props: {
     section: String,
     sectionId: String,
   },
+  components: {
+    Icon,
+  },
 };
 </script>
+
+<style>
+.edit-button {
+  border: none;
+  background: none;
+  color: var(--black);
+}
+.edit-button:hover {
+  color: var(--blue-60);
+}
+.profile__section-header .edit-button {
+  position: absolute;
+  top: 1.5em;
+  right: 1.5em;
+}
+.profile__intro .edit-button {
+  position: absolute;
+  top: 1em;
+  right: 0;
+}
+</style>

--- a/src/components/profile/edit/EditButton.vue
+++ b/src/components/profile/edit/EditButton.vue
@@ -1,0 +1,25 @@
+<template>
+  <button
+    class="profile__edit-button"
+    @click="
+      $router.push({
+        name: 'Edit Profile',
+        query: {
+          section: sectionId,
+        },
+      })
+    "
+  >
+    <img src="@/assets/images/icon-pencil.svg" :alt="`Edit ${section}`" />
+  </button>
+</template>
+
+<script>
+export default {
+  name: 'EditButton',
+  props: {
+    section: String,
+    sectionId: String,
+  },
+};
+</script>

--- a/src/components/profile/edit/EditButton.vue
+++ b/src/components/profile/edit/EditButton.vue
@@ -1,17 +1,15 @@
 <template>
-  <button
+  <RouterLink
     class="profile__edit-button"
-    @click="
-      $router.push({
-        name: 'Edit Profile',
-        query: {
-          section: sectionId,
-        },
-      })
-    "
+    :to="{
+      name: 'Edit Profile',
+      query: {
+        section: sectionId,
+      },
+    }"
   >
     <img src="@/assets/images/icon-pencil.svg" :alt="`Edit ${section}`" />
-  </button>
+  </RouterLink>
 </template>
 
 <script>

--- a/src/components/profile/view/EmptyCard.vue
+++ b/src/components/profile/view/EmptyCard.vue
@@ -2,6 +2,7 @@
   <section class="profile__section profile__section--disabled">
     <header class="profile__section-header">
       <h2>{{ title }}</h2>
+      <slot name="header"></slot>
     </header>
     <slot></slot>
     <p>{{ message }}</p>

--- a/src/components/profile/view/ViewAccounts.vue
+++ b/src/components/profile/view/ViewAccounts.vue
@@ -82,7 +82,7 @@ export default {
     accounts() {
       const wellKnown = Object.entries(this.uris.values || {})
         .map((kv) => this.account(kv))
-        .filter((a) => a !== null && typeof a !== 'undefined');
+        .filter((a) => a !== null && typeof a !== 'undefined' && a.value);
       const mozilla = wellKnown.filter(({ moz }) => moz);
       const other = wellKnown.filter(({ moz }) => !moz);
       return { mozilla, other };

--- a/src/components/profile/view/ViewAccounts.vue
+++ b/src/components/profile/view/ViewAccounts.vue
@@ -2,20 +2,11 @@
   <div>
     <header class="profile__section-header">
       <h2>Accounts</h2>
-      <button
-        class="profile__edit-button"
+      <EditButton
         v-if="userOnOwnProfile"
-        @click="
-          $router.push({
-            name: 'Edit Profile',
-            query: {
-              section: 'accounts',
-            },
-          })
-        "
-      >
-        <img src="@/assets/images/icon-pencil.svg" alt="Edit accounts" />
-      </button>
+        section="accounts"
+        sectionId="accounts"
+      ></EditButton>
     </header>
     <div class="profile__external-accounts">
       <div v-if="accounts.mozilla.length">
@@ -64,6 +55,7 @@
 
 <script>
 import AccountsMixin from '@/components/_mixins/AccountsMixin.vue';
+import EditButton from '@/components/profile/edit/EditButton.vue';
 import IconBlock from '@/components/ui/IconBlock.vue';
 import IconBlockList from '@/components/ui/IconBlockList.vue';
 
@@ -75,6 +67,7 @@ export default {
   },
   mixins: [AccountsMixin],
   components: {
+    EditButton,
     IconBlock,
     IconBlockList,
   },

--- a/src/components/profile/view/ViewContact.vue
+++ b/src/components/profile/view/ViewContact.vue
@@ -27,6 +27,7 @@
 </template>
 
 <script>
+import EditButton from '@/components/profile/edit/EditButton.vue';
 import IconBlock from '@/components/ui/IconBlock.vue';
 import IconBlockList from '@/components/ui/IconBlockList.vue';
 
@@ -38,6 +39,7 @@ export default {
     userOnOwnProfile: Boolean,
   },
   components: {
+    EditButton,
     IconBlock,
     IconBlockList,
   },

--- a/src/components/profile/view/ViewContact.vue
+++ b/src/components/profile/view/ViewContact.vue
@@ -2,20 +2,11 @@
   <div>
     <header class="profile__section-header">
       <h2>Contact</h2>
-      <button
+      <EditButton
         v-if="userOnOwnProfile"
-        class="profile__edit-button"
-        @click="
-          $router.push({
-            name: 'Edit Profile',
-            query: {
-              section: 'contact',
-            },
-          })
-        "
-      >
-        <img src="@/assets/images/icon-pencil.svg" alt="Edit" />
-      </button>
+        section="contact"
+        sectionId="contact"
+      ></EditButton>
     </header>
     <h3 class="visually-hidden">Contact options</h3>
     <IconBlockList modifier="icon-block-list--multi-col">

--- a/src/components/profile/view/ViewLanguages.vue
+++ b/src/components/profile/view/ViewLanguages.vue
@@ -18,6 +18,7 @@
 </template>
 
 <script>
+import EditButton from '@/components/profile/edit/EditButton.vue';
 import Tag from '@/components/ui/Tag.vue';
 
 export default {
@@ -27,6 +28,7 @@ export default {
     userOnOwnProfile: Boolean,
   },
   components: {
+    EditButton,
     Tag,
   },
 };

--- a/src/components/profile/view/ViewLanguages.vue
+++ b/src/components/profile/view/ViewLanguages.vue
@@ -2,20 +2,11 @@
   <div>
     <header class="profile__section-header">
       <h2>Languages</h2>
-      <button
-        class="profile__edit-button"
-        v-if="userOnOwnProfile && true === false"
-        @click="
-          $router.push({
-            name: 'Edit Profile',
-            query: {
-              section: 'languages',
-            },
-          })
-        "
-      >
-        <img src="@/assets/images/icon-pencil.svg" alt="Edit languages" />
-      </button>
+      <EditButton
+        v-if="userOnOwnProfile"
+        section="languages"
+        sectionId="languages"
+      ></EditButton>
     </header>
     <Tag
       v-for="(language, index) in languages.values"

--- a/src/components/profile/view/ViewPersonalInfo.vue
+++ b/src/components/profile/view/ViewPersonalInfo.vue
@@ -1,19 +1,10 @@
 <template>
   <div class="profile__intro">
-    <button
+    <EditButton
       v-if="userOnOwnProfile"
-      class="profile__edit-button"
-      @click="
-        $router.push({
-          name: 'Edit Profile',
-          query: {
-            section: 'personal-info',
-          },
-        })
-      "
-    >
-      <img src="@/assets/images/icon-pencil.svg" alt="Edit" />
-    </button>
+      section="personal info"
+      sectionId="personal-info"
+    ></EditButton>
     <div class="profile__intro-photo">
       <div class="profile__headshot">
         <UserPicture

--- a/src/components/profile/view/ViewPersonalInfo.vue
+++ b/src/components/profile/view/ViewPersonalInfo.vue
@@ -87,6 +87,7 @@
 <script>
 import CompanyMixin from '@/components/_mixins/CompanyMixin.vue';
 import ContactMe from '@/components/ui/ContactMe.vue';
+import EditButton from '@/components/profile/edit/EditButton.vue';
 import Icon from '@/components/ui/Icon.vue';
 import Meta from '@/components/ui/Meta.vue';
 import MetaList from '@/components/ui/MetaList.vue';
@@ -120,6 +121,7 @@ export default {
   },
   components: {
     ContactMe,
+    EditButton,
     Icon,
     Meta,
     MetaList,
@@ -153,19 +155,6 @@ export default {
     grid-template-columns: 1fr 2fr;
   }
 }
-
-.profile__edit-button {
-  position: absolute;
-  top: 2em;
-  right: 2em;
-  border: none;
-  background: none;
-}
-
-.profile__edit-button img {
-  width: 18px;
-}
-
 .profile__intro-photo {
   text-align: center;
 }

--- a/src/components/profile/view/ViewTags.vue
+++ b/src/components/profile/view/ViewTags.vue
@@ -2,20 +2,11 @@
   <div>
     <header class="profile__section-header">
       <h2>Tags</h2>
-      <button
-        class="profile__edit-button"
-        v-if="userOnOwnProfile && true === false"
-        @click="
-          $router.push({
-            name: 'Edit Profile',
-            query: {
-              section: 'tags',
-            },
-          })
-        "
-      >
-        <img src="@/assets/images/icon-pencil.svg" alt="Edit tags" />
-      </button>
+      <EditButton
+        v-if="userOnOwnProfile"
+        section="tags"
+        sectionId="tags"
+      ></EditButton>
     </header>
     <Tag v-for="(tag, index) in tags.values" :tag="tag" :key="`tag-${index}`" />
   </div>

--- a/src/components/ui/Icon.vue
+++ b/src/components/ui/Icon.vue
@@ -335,7 +335,7 @@
     </template>
     <template v-else-if="id === 'pencil'">
       <path
-        stroke="currentColor"
+        fill="currentColor"
         d="M21.7 7.3l-5-5c-.4-.4-1-.4-1.4 0l-13 13c-.2.2-.3.4-.3.7v5c0 .6.4 1 1 1h5c.3 0 .5-.1.7-.3l13-13c.4-.4.4-1 0-1.4zM7.6 20H4v-3.6l12-12L19.6 8l-12 12z"
       />
     </template>


### PR DESCRIPTION
This PR: changes deciding which sections to show, adds edit button to empty card states if user is on own profile.

Other changes:

* uses `EditButton` component instead of repeating the same; it's also a `RouterLink` now