### PR TITLE
Remove edit from languages for now

### DIFF
--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -131,13 +131,6 @@
     </section>
     <EmptyCard v-else title="Languages" message="No languages have been added">
       <a id="nav-languages" class="profile__anchor"></a>
-      <template v-slot:header>
-        <EditButton
-          v-if="userOnOwnProfile"
-          section="languages"
-          sectionId="languages"
-        ></EditButton>
-      </template>
     </EmptyCard>
     <section
       v-if="sections.tags"


### PR DESCRIPTION
As discussed with Linda; even if the languages card is empty, we don't want a route to the edit screen as that's out of scope for now