### PR TITLE
Use whole numbers for r, g and b (DP-1172)

### DIFF
--- a/src/components/profile/edit/EditMutationWrapper.vue
+++ b/src/components/profile/edit/EditMutationWrapper.vue
@@ -144,7 +144,7 @@ export default {
   left: 0px;
   width: 100%;
   height: 100%;
-  background: rgba(0.5, 0.5, 0.5, 0.5);
+  background: rgba(0, 0, 0, 0.2);
   display: flex;
   align-items: center;
   flex-direction: row;


### PR DESCRIPTION
This fixes the bug where there was no semitransparent background in near-most-recent Safari, addresses DP-1172 again.