### PR TITLE
Replace the term "contributor" with "volunteer"

### DIFF
--- a/src/components/search/SearchScope.vue
+++ b/src/components/search/SearchScope.vue
@@ -35,13 +35,13 @@
         />
         <label for="search-who-staff">Staff</label>
         <input
-          id="search-who-contributors"
+          id="search-who-volunteers"
           type="radio"
-          value="contributors"
+          value="volunteers"
           name="who"
           v-model="who"
         />
-        <label for="search-who-contributors">Contributors</label>
+        <label for="search-who-volunteers">Volunteers</label>
       </div>
     </fieldset>
     <input


### PR DESCRIPTION
Mitchell said something about these terms many years ago which always
stuck with me. Paraphrased, she said something like this:

"We are all contributors. Some of us are paid. Others volunteer their
time."

Although I can't find any formal guidelines about this, I notice that
Mozilla generally follows Mitchell's guidance. For example, the "Our
Contributors" page lists both paid and unpaid people,[1] we refer to
unpaid work as "volunteer opportunities" on mozilla.org,[2] and the
careers page uses the phrase "paid and volunteer contributors."[3]

[1] https://www.mozilla.org/credits/
[2] https://www.mozilla.org/contribute/
[3] https://careers.mozilla.org/