### PR TITLE
Fix click outside without breaking org chart

### DIFF
--- a/src/components/_functional/ShowMore.vue
+++ b/src/components/_functional/ShowMore.vue
@@ -22,19 +22,29 @@
       type="button"
       :aria-expanded="isExpanded ? 'true' : 'false'"
       v-on:click="toggleOverflow"
+      ref="button"
     >
       <template v-if="isExpanded">
         <slot name="icon-expanded"></slot>
-        <span class="show-more__button-text">{{ alternateButtonText }}</span>
+        <span :class="`show-more__button-text${buttonTextClass}`">{{
+          alternateButtonText || buttonText
+        }}</span>
       </template>
       <template v-else>
         <slot name="icon-collapsed"></slot>
-        <span class="show-more__button-text">{{ buttonText }}</span>
+        <span :class="`show-more__button-text${buttonTextClass}`">{{
+          buttonText
+        }}</span>
       </template>
       <slot name="button-content"></slot>
     </button>
     <transition v-if="overflowBefore === false" name="show-more__overflow-">
-      <div class="show-more__overflow" v-if="isExpanded" tabindex="-1">
+      <div
+        class="show-more__overflow"
+        v-if="isExpanded"
+        tabindex="-1"
+        ref="overflowContentElement"
+      >
         <slot name="overflow"> </slot>
       </div>
     </transition>
@@ -61,6 +71,10 @@ export default {
     overflowBefore: {
       type: Boolean,
       default: true,
+    },
+    buttonTextVisuallyHidden: {
+      type: Boolean,
+      default: false,
     },
   },
   methods: {
@@ -96,16 +110,27 @@ export default {
       this.isExpanded = this.expanded;
     },
   },
+  computed: {
+    buttonTextClass() {
+      let buttonClass = '';
+
+      if (this.buttonTextVisuallyHidden) {
+        buttonClass = ' visually-hidden';
+      }
+
+      return buttonClass;
+    },
+  },
   updated() {
     const overflowContent = this.$refs.overflowContentElement;
 
     if (this.isExpanded && this.moveFocus) {
       overflowContent.focus();
+    }
 
-      if (this.closeWhenClickedOutside) {
-        document.addEventListener('click', this.handleDocumentClick);
-        document.addEventListener('touchstart', this.handleDocumentClick);
-      }
+    if (this.isExpanded && this.closeWhenClickedOutside) {
+      document.addEventListener('click', this.handleDocumentClick);
+      document.addEventListener('touchstart', this.handleDocumentClick);
     } else if (this.closeWhenClickedOutside) {
       document.removeEventListener('click', this.handleDocumentClick);
       document.removeEventListener('touchstart', this.handleDocumentClick);


### PR DESCRIPTION
In a previous version, my clicked outside broke the org chart, this no longer does that.

It is based on the tooltip branch, so we best merge this after that.