### PR TITLE
Increase avatar picture quality in user menu

### DIFF
--- a/src/components/ui/TopBar.vue
+++ b/src/components/ui/TopBar.vue
@@ -72,7 +72,7 @@
             <UserPicture
               :picture="user.picture.value"
               :username="user.primaryUsername.value"
-              :size="264"
+              :size="100"
               dinoType="Staff"
             ></UserPicture>
           </template>

--- a/src/components/ui/TopBar.vue
+++ b/src/components/ui/TopBar.vue
@@ -72,7 +72,7 @@
             <UserPicture
               :picture="user.picture.value"
               :username="user.primaryUsername.value"
-              :size="40"
+              :size="264"
               dinoType="Staff"
             ></UserPicture>
           </template>

--- a/src/components/ui/UserMenu.vue
+++ b/src/components/ui/UserMenu.vue
@@ -10,7 +10,7 @@
         <UserPicture
           :picture="user.picture.value"
           :username="user.primaryUsername.value"
-          :size="264"
+          :size="100"
         ></UserPicture>
       </button>
       <div class="user-menu__name">

--- a/src/components/ui/UserMenu.vue
+++ b/src/components/ui/UserMenu.vue
@@ -10,7 +10,7 @@
         <UserPicture
           :picture="user.picture.value"
           :username="user.primaryUsername.value"
-          :size="40"
+          :size="264"
         ></UserPicture>
       </button>
       <div class="user-menu__name">


### PR DESCRIPTION
**Benefit:** 
The user avatar is less blurry.

**Drawback:**
This change requires browsers to download more data because the image will be delivered in a higher quality.

**Mitigation:**
The avatar quality is only increased for the user menu, **not** for the org chart or profile page. This limits the bandwidth increase to 1 avatar picture per user.

**Before:**
<img width="308" alt="image" src="https://user-images.githubusercontent.com/869692/56658027-d456d280-6699-11e9-8e0b-e9c823f43dbe.png">

**After:**
<img width="308" alt="image" src="https://user-images.githubusercontent.com/869692/56658056-e9336600-6699-11e9-99fc-377241b0cddd.png">

