### PR TITLE
Popover Fixes

### DIFF
--- a/src/components/ui/Popover.vue
+++ b/src/components/ui/Popover.vue
@@ -32,17 +32,11 @@ export default {
         this.position = 'left';
       }
 
-      if (
-        this.position === 'right' &&
-        spaceOnLeft + this.maxWidth > viewportWidth
-      ) {
-        this.maxWidth = viewportWidth - spaceOnLeft;
+      if (this.position === 'right' && spaceOnRight < this.maxWidth) {
+        this.maxWidth = spaceOnRight;
       }
-      if (
-        this.position === 'left' &&
-        spaceOnRight + this.maxWidth > viewportWidth
-      ) {
-        this.maxWidth = viewportWidth - spaceOnRight;
+      if (this.position === 'left' && spaceOnLeft < this.maxWidth) {
+        this.maxWidth = spaceOnLeft;
       }
     },
   },
@@ -132,5 +126,8 @@ export default {
   .popover--right {
     transform: translateX(calc(100% - 0.75em));
   }
+}
+.popover a {
+  background-color: var(--white);
 }
 </style>

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -21,7 +21,7 @@
         :height="17"
       ></Icon>
     </button>
-    <Popover v-show="open">
+    <Popover v-if="open">
       <fieldset
         @keydown.enter.prevent="closeList"
         :id="`option-list-${id}`"
@@ -90,17 +90,17 @@ export default {
       if (this.open) {
         this.open = false;
       } else {
-        const list = this.$refs[`optionList-${this.id}`];
-        const optionToFocus =
-          list.querySelector('input:checked') || list.querySelector('input');
-
         this.open = true;
 
-        if (optionToFocus) {
-          this.$nextTick(() => {
+        this.$nextTick(() => {
+          const list = this.$refs[`optionList-${this.id}`];
+          const optionToFocus =
+            list.querySelector('input:checked') || list.querySelector('input');
+
+          if (optionToFocus) {
             optionToFocus.focus();
-          });
-        }
+          }
+        });
       }
     },
     closeList() {
@@ -163,6 +163,7 @@ export default {
 .options {
   position: relative;
   display: inline-block;
+  align-self: start;
 }
 .options__toggle {
   font-size: inherit;


### PR DESCRIPTION
- only mount popover when its open, otherwise bbox calculaion was off in places where new layouting happened
- use the spaceOnLeft/spaceOnRight to set the maxWidth (@hidde I didn't figure out what the original code's intention was here, please lmk if I missed something)