### PR TITLE
Explicitly set white transparancy, addresses Safari bug

### DIFF
--- a/src/components/profile/ProfileDescription.vue
+++ b/src/components/profile/ProfileDescription.vue
@@ -42,6 +42,6 @@ export default {
   top: calc(100% - 3em);
   height: 3em;
   width: 100%;
-  background: linear-gradient(transparent 0, var(--white) 100%);
+  background: linear-gradient(rgba(255, 255, 255, 0) 0, var(--white) 100%);
 }
 </style>


### PR DESCRIPTION
Apparently Safari sometimes treats the `transparant` keyboard as transparant black, which causes the iOS issue mentioned in DP-1190. See also: https://stackoverflow.com/questions/11829410/css3-gradient-rendering-issues-from-transparent-to-white

This is more explicit and doesn't break in other browsers.