### PR TITLE
Improve edit and privacy icons on profile photo (fix DP-1268)

### DIFF
--- a/src/components/profile/edit/EditPersonalInfo.vue
+++ b/src/components/profile/edit/EditPersonalInfo.vue
@@ -519,9 +519,21 @@ export default {
   .user-picture
   ~ .edit-personal-info__picture-edit-button,
 .edit-personal-info__picture .user-picture ~ .privacy-setting {
-  display: inline-block;
+  display: inline-flex;
   vertical-align: bottom;
   margin-right: 0.5em;
+}
+.edit-personal-info__picture .edit-personal-info__picture-privacy button,
+.edit-personal-info__picture .edit-personal-info__picture-edit-button {
+  background-color: var(--white);
+  font-size: inherit;
+  display: flex;
+  border-radius: var(--imageRadius);
+  color: var(--black);
+  border: 1px solid var(--gray-50);
+}
+.edit-personal-info__picture .edit-personal-info__picture-edit-button svg {
+  margin: 0;
 }
 .edit-personal-info__meta {
   grid-column: 1 / 2;
@@ -583,12 +595,17 @@ export default {
   .edit-personal-info__picture .edit-personal-info__picture-edit-button {
     position: absolute;
     top: 15.5em;
-    background-color: var(--gray-20);
-    font-size: inherit;
-    display: flex;
-    border-radius: var(--imageRadius);
-    color: var(--black);
+  }
+  .edit-personal-info__picture .edit-personal-info__picture-privacy button,
+  .edit-personal-info__picture .edit-personal-info__picture-edit-button {
     border-color: transparent;
+  }
+  .edit-personal-info__picture
+    .edit-personal-info__picture-privacy
+    button:hover,
+  .edit-personal-info__picture .edit-personal-info__picture-edit-button:hover {
+    border-color: var(--blue-60);
+    color: var(--blue-60);
   }
   .edit-personal-info__picture-edit-button {
     left: 1.1em;


### PR DESCRIPTION
Also improves what they look like on small screens (where they are not _on_ a profile photo but next to one): 

<img width="194" alt="user photo with two icon only buttons next to it" src="https://user-images.githubusercontent.com/178782/56897350-9b9a6d00-6a8e-11e9-84fc-6eaba3fbbed1.png">
