### PR TITLE
Center ContactMe in desktop profile (fixes DP-1269)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -200,7 +200,7 @@ abbr {
 }
 @media (min-width: 57.5em) {
   .hide-mobile {
-    display: initial;
+    display: block;
   }
   .hide-desktop {
     display: none;

--- a/src/App.vue
+++ b/src/App.vue
@@ -192,16 +192,15 @@ abbr {
   white-space: nowrap;
 }
 
-/* best only use these classes on elements that
-     do not have anything else, we don't want it
-     to interfere with other display values */
-.hide-mobile {
-  display: none;
+/* best only use these classes on their own, and use a
+   wrapping container to not interfere with an element's 
+   existing display value */
+@media not screen and (min-width: 57.5em) {
+  .hide-mobile {
+    display: none;
+  }
 }
 @media (min-width: 57.5em) {
-  .hide-mobile {
-    display: block;
-  }
   .hide-desktop {
     display: none;
   }

--- a/src/components/profile/view/ViewPersonalInfo.vue
+++ b/src/components/profile/view/ViewPersonalInfo.vue
@@ -14,7 +14,7 @@
           :isStaff="staffInformation.staff.value"
         ></UserPicture>
       </div>
-      <div class="hide-mobile">
+      <div class="hide-mobile profile__contact-me-container">
         <ContactMe
           :primaryEmail="primaryEmail.value"
           :phoneNumbers="phoneNumbers"
@@ -190,6 +190,9 @@ export default {
     width: 18.75em;
     height: 18.75em;
     margin-left: 0;
+  }
+  .profile__contact-me-container {
+    width: 18.75em;
   }
   .profile__intro-photo .profile__headshot {
     margin: 0 0 4em;


### PR DESCRIPTION
This makes the container that Contact Me is in as wide as the container the profile pic is in, so that centering works.

Note: this also changes the `hide-mobile` utility class. 

In desktop, it was set to `display: initial`, as I wanted to avoid setting it to `display: block`, as then it would have weird effects if used on elements that were initially set to other display modes, eg `flex` or `table` or `grid`.

I've double checked, in all cases where we currently use `hide-mobile`, it was fine to be set to `display: block` on desktop.