### PR TITLE
Fix DP-1300

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -163,7 +163,6 @@ abbr {
 
 .container {
   padding: 0 1em;
-  flex: 1;
   width: 100%;
 }
 @media (min-width: 57.5em) {
@@ -178,6 +177,10 @@ abbr {
   flex-direction: column;
   max-width: 100vw;
   min-height: 100vh;
+}
+.app-container > .container,
+.app-container > div[username] {
+  flex: 1;
 }
 
 .visually-hidden {

--- a/src/App.vue
+++ b/src/App.vue
@@ -2,7 +2,7 @@
   <div id="app" class="app-container">
     <Banner v-if="showBanner" @close="showBanner = false" ref="banner" />
     <TopBar></TopBar>
-    <RouterView />
+    <RouterView class="container" />
     <Footer></Footer>
   </div>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -178,8 +178,7 @@ abbr {
   max-width: 100vw;
   min-height: 100vh;
 }
-.app-container > .container,
-.app-container > div[username] {
+.app-container > .container {
   flex: 1;
 }
 

--- a/src/pages/PageHome.vue
+++ b/src/pages/PageHome.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="container home">
+  <main class="home">
     <div class="home__intro">
       <img
         src="@/assets/images/laptop-phone.jpg"

--- a/src/pages/PageOrgchart.vue
+++ b/src/pages/PageOrgchart.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="container org-chart">
+  <main class="org-chart">
     <div class="org-chart__chart">
       <OrgRoot
         v-if="tree && !loading"

--- a/src/pages/PageProfile.vue
+++ b/src/pages/PageProfile.vue
@@ -5,7 +5,7 @@
     clientId="mutationClient"
   >
     <template slot-scope="{ result: { loading, data, error } }">
-      <main v-if="loading" class="container"><LoadingSpinner /></main>
+      <LoadingSpinner v-if="loading"></LoadingSpinner>
       <template v-else-if="data && data.profile !== null">
         <Profile
           v-bind="data.profile"
@@ -19,7 +19,7 @@
         ></Profile>
       </template>
       <Page404 v-else-if="error || (data && data.profile === null)"></Page404>
-      <main v-else class="container"><LoadingSpinner /></main>
+      <LoadingSpinner v-else></LoadingSpinner>
     </template>
   </ApolloQuery>
 </template>

--- a/src/pages/PageProfile.vue
+++ b/src/pages/PageProfile.vue
@@ -5,7 +5,7 @@
     clientId="mutationClient"
   >
     <template slot-scope="{ result: { loading, data, error } }">
-      <LoadingSpinner v-if="loading"></LoadingSpinner>
+      <main v-if="loading" class="container"><LoadingSpinner /></main>
       <template v-else-if="data && data.profile !== null">
         <Profile
           v-bind="data.profile"
@@ -19,7 +19,7 @@
         ></Profile>
       </template>
       <Page404 v-else-if="error || (data && data.profile === null)"></Page404>
-      <LoadingSpinner v-else></LoadingSpinner>
+      <main v-else class="container"><LoadingSpinner /></main>
     </template>
   </ApolloQuery>
 </template>

--- a/src/pages/PageSearchResult.vue
+++ b/src/pages/PageSearchResult.vue
@@ -1,9 +1,5 @@
 <template>
-  <main
-    class="container search-results"
-    ref="searchResultsContainer"
-    tabindex="-1"
-  >
+  <main class="search-results" ref="searchResultsContainer" tabindex="-1">
     <h1 class="visually-hidden">Search results</h1>
     <SearchScope />
     <template v-if="!this.$route.query.query">

--- a/src/pages/PageUnknown.vue
+++ b/src/pages/PageUnknown.vue
@@ -1,5 +1,5 @@
 <template>
-  <main class="container">
+  <main>
     <Error>
       <template slot="image">
         <img
@@ -22,7 +22,8 @@
         >
         <p>
           <small
-            >Please submit all bugs or issues to the project's GitHub issue repository (link in footer).</small
+            >Please submit all bugs or issues to the project's GitHub issue
+            repository (link in footer).</small
           >
         </p>
       </template>


### PR DESCRIPTION
We use `flex: 1` to make the element between header and footer span all leftover space. 

It did not apply in profiles, because `vue-apollo`'s `ApolloQuery` component wraps itself in a div that does not have a container class. Therefore the thing with `.container` was no longer a direct child of the app.

Fixed by setting `container` class on each router view. This makes sense as whatever the router view is, we want it to have this behaviour.