### PR TITLE
Add custom checkboxes, use in accounts/contacts editing (fixes DP-1107)

### DIFF
--- a/src/components/profile/edit/EditAccounts.vue
+++ b/src/components/profile/edit/EditAccounts.vue
@@ -48,14 +48,12 @@
           `Your username on ${EXTERNAL_ACCOUNTS[destructUriKey(k).name].text}`
         "
       />
-      <label class="edit-contact__set-as-contact"
-        ><input
-          type="checkbox"
-          v-on:change="(e) => toggleUriContactMe(e, index)"
-          :checked="destructUriKey(k).contact"
-        />
-        Show in Contact Me button</label
-      >
+      <Checkbox
+        @input="(newValue) => toggleUriContactMe(newValue, index)"
+        :checked="destructUriKey(k).contact"
+        label="Show in Contact Me button"
+        class="edit-contact__set-as-contact"
+      />
       <hr role="presentation" />
     </div>
     <Button
@@ -71,6 +69,7 @@
 <script>
 import AccountsMixin from '@/components/_mixins/AccountsMixin.vue';
 import Button from '@/components/ui/Button.vue';
+import Checkbox from '@/components/ui/Checkbox.vue';
 import Icon from '@/components/ui/Icon.vue';
 import PrivacySetting from '@/components/profile/PrivacySetting.vue';
 import Select from '@/components/ui/Select.vue';
@@ -91,11 +90,12 @@ export default {
   },
   mixins: [AccountsMixin],
   components: {
+    Button,
+    Checkbox,
     EditMutationWrapper,
     Icon,
     PrivacySetting,
     Select,
-    Button,
   },
   methods: {
     displayLevelsFor,
@@ -119,9 +119,9 @@ export default {
         this.uris.values.splice(index, 1);
       }
     },
-    toggleUriContactMe(e, index) {
+    toggleUriContactMe(checked, index) {
       const account = this.destructUriKey(this.uris.values[index].k, index);
-      account.contact = e.target.checked;
+      account.contact = checked;
       this.uris.values[index].k = this.constructUriKey(account);
     },
   },

--- a/src/components/profile/edit/EditContact.vue
+++ b/src/components/profile/edit/EditContact.vue
@@ -36,10 +36,12 @@
           :profileFieldObject="primaryEmail"
           :disabled="true"
         />
-        <label class="edit-contact__set-as-contact"
-          ><input type="checkbox" checked disabled /> Show in Contact Me
-          button</label
-        >
+        <Checkbox
+          :checked="true"
+          label="Show in Contact Me button"
+          class="edit-contact__set-as-contact"
+          :disabled="true"
+        />
         <hr role="presentation" />
       </div>
       <div class="edit-contact__info">Add / Remove Email via Identities</div>
@@ -82,14 +84,12 @@
           placeholder="Phone number"
           v-model="phoneNumbers.values[index].v"
         />
-        <label class="edit-contact__set-as-contact"
-          ><input
-            type="checkbox"
-            v-on:change="(e) => togglePhoneNumberContactMe(e, index)"
-            :checked="destructPhoneKey(k).contact"
-          />
-          Show in Contact Me button</label
-        >
+        <Checkbox
+          @input="(newValue) => togglePhoneNumberContactMe(newValue, index)"
+          :checked="destructPhoneKey(k).contact"
+          label="Show in Contact Me button"
+          class="edit-contact__set-as-contact"
+        />
         <hr role="presentation" />
       </div>
       <hr role="presentation" />
@@ -104,6 +104,7 @@
 </template>
 
 <script>
+import Checkbox from '@/components/ui/Checkbox.vue';
 import PhoneNumbersMixin from '@/components/_mixins/PhoneNumbersMixin.vue';
 import Button from '@/components/ui/Button.vue';
 import EditMutationWrapper from './EditMutationWrapper.vue';
@@ -123,6 +124,7 @@ export default {
   mixins: [PhoneNumbersMixin],
   components: {
     Button,
+    Checkbox,
     EditMutationWrapper,
     Icon,
     PrivacySetting,
@@ -144,12 +146,12 @@ export default {
         this.phoneNumbers.values.splice(index, 1);
       }
     },
-    togglePhoneNumberContactMe(e, index) {
+    togglePhoneNumberContactMe(newValue, index) {
       const number = this.destructPhoneKey(
         this.phoneNumbers.values[index].k,
         index,
       );
-      number.contact = e.target.checked;
+      number.contact = newValue;
       this.phoneNumbers.values[index].k = this.constructPhoneKey(number);
     },
     phoneNumberLabels(k, index) {

--- a/src/components/ui/Checkbox.vue
+++ b/src/components/ui/Checkbox.vue
@@ -1,0 +1,62 @@
+<template>
+  <label class="checkbox">
+    <input
+      type="checkbox"
+      :name="name"
+      :value="value"
+      :checked="checked"
+      :disabled="disabled"
+      @change="emitChange"
+      class="visually-hidden"
+    />
+    <Icon v-if="checked" id="successSquare" :width="14" :height="14" />
+    <Icon v-else id="square" :width="14" :height="14" />
+    {{ label }}
+  </label>
+</template>
+
+<script>
+import Icon from '@/components/ui/Icon.vue';
+
+export default {
+  name: 'Checkbox',
+  props: {
+    label: String,
+    name: String,
+    value: String,
+    checked: Boolean,
+    disabled: Boolean,
+  },
+  methods: {
+    emitChange(event) {
+      this.$emit('input', event.target.checked);
+    },
+  },
+  components: {
+    Icon,
+  },
+};
+</script>
+
+<style>
+.checkbox {
+  padding-left: 1.75em;
+  position: relative;
+}
+.checkbox input + svg {
+  color: var(--gray-50);
+  position: absolute;
+  top: 0.25em;
+  left: 0;
+}
+.focus-styles .checkbox input:focus + svg {
+  box-shadow: 0px 0 0 1px var(--blue-60), 0 0 0 3px var(--transparentBlue);
+}
+.checkbox input:checked + svg {
+  color: var(--blue-60);
+}
+.checkbox input[disabled] + svg {
+  color: var(--gray-30);
+  cursor: not-allowed;
+}
+</style>

--- a/src/components/ui/Icon.vue
+++ b/src/components/ui/Icon.vue
@@ -374,6 +374,25 @@
         fill-rule="evenodd"
       />
     </template>
+    <template v-else-if="id === 'square'">
+      <rect
+        x="3"
+        y="3"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="2"
+        rx="2"
+        width="18"
+        height="18"
+        ry="2"
+      />
+    </template>
+    <template v-else-if="id === 'successSquare'">
+      <path
+        fill="currentColor"
+        d="M19 2c1.7 0 3 1.3 3 3v14c0 1.7-1.3 3-3 3H5c-1.7 0-3-1.3-3-3V5c0-1.7 1.3-3 3-3h14zm-2.3 8.7c.4-.4.4-1 0-1.4-.4-.4-1-.4-1.4 0L11 13.6l-2.3-2.3c-.4-.4-1-.4-1.4 0-.4.4-.4 1 0 1.4l3 3c.2.2.4.3.7.3.3 0 .5-.1.7-.3l5-5z"
+      />
+    </template>
   </svg>
 </template>
 


### PR DESCRIPTION
Note: this modifies `toggleUriContactMe` and `togglePhoneNumberContactMe` functions to get their uri/phone number not from `e.target.value` but directly from the value. 

This is so that the checkbox can just emit the value. I believe this makes `Checkbox` more default/what one would expect it to do. I could very much be wrong, second opinion appreciated! 