### PR TITLE
Convey Select's selected state with inline SVG (DP-1279)

### DIFF
--- a/src/components/ui/Option.vue
+++ b/src/components/ui/Option.vue
@@ -14,9 +14,17 @@
         :width="17"
         :height="17"
         v-if="icon && expandedShowIcon"
+        class="options__option-icon"
       ></Icon>
-      <span v-if="expandedShowLabel">{{ label }}</span></label
-    >
+      <span v-if="expandedShowLabel">{{ label }}</span>
+      <Icon
+        id="check"
+        :width="24"
+        :height="24"
+        v-if="checked"
+        class="options__option-checked"
+      ></Icon>
+    </label>
   </li>
 </template>
 

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -205,29 +205,26 @@ export default {
   text-decoration: none;
   color: inherit;
 }
-.options__option svg {
+.options__option-icon {
   width: 2em;
   margin-right: 0.75em;
+}
+.options__option-checked {
+  margin-left: auto;
+  color: var(--blue-60);
 }
 .options input {
   position: absolute;
   opacity: 0;
 }
 .options label {
-  padding: 0.75em 1em;
+  padding: 0.75em 0.5em 0.75em 1em;
   margin: 0;
   display: flex;
   align-items: center;
-  padding-right: 3em;
 }
 .options label:hover {
   background-color: var(--lightBlue);
-}
-.options input:checked + label {
-  background-image: url('../../assets/images/check-blue.svg');
-  background-repeat: no-repeat;
-  background-position: center right 0.75em;
-  background-size: 1.5em;
 }
 .focus-styles .options input:focus + label {
   position: relative;


### PR DESCRIPTION
I am hoping this work addresses DP-1279 (selected state check icon is not visible in high contrast mode).

Before: used background image of check icon
After: use `Icon` component (yields inline svg), shown conditionally based on state