### PR TITLE
Improve DinoPark in high contrast modes

### DIFF
--- a/src/components/profile/edit/EditPersonalInfo.vue
+++ b/src/components/profile/edit/EditPersonalInfo.vue
@@ -496,6 +496,7 @@ export default {
   background-color: transparent;
   border-color: transparent;
   color: var(--gray-50);
+  -webkit-text-fill-color: var(--gray-50);
   padding-left: 0;
   opacity: 1;
 }

--- a/src/components/ui/LoadingSpinner.vue
+++ b/src/components/ui/LoadingSpinner.vue
@@ -7,7 +7,7 @@
       height="38"
       viewBox="0 0 38 38"
       xmlns="http://www.w3.org/2000/svg"
-      stroke="#000"
+      stroke="currentColor"
     >
       <title id="loading__spinner__title">Loading...</title>
       <g fill="none" fill-rule="evenodd">


### PR DESCRIPTION
This fixes outstanding issues:

* in DP-314: disabled inputs were too gray in Safari, fixed with proprietary `-webkit-text-fill-color` 
* in DP-1279: spinner invisible in high contrast mode, fixed by making color `currentColor` instead of forcing `#000` 