### PR TITLE
Improve keyboard nav

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -66,6 +66,8 @@ export default {
   --layerModal: 9;
 
   --shadowCard: 0 0.25em 0.25em 0 rgba(210, 210, 210, 0.5);
+  --focusOutlineShadow: 0px 0 0 1px var(--blue-60),
+    0 0 0 3px var(--transparentBlue);
 
   --imageRadius: 0.25em;
   --formElementRadius: 0.25em;
@@ -216,7 +218,7 @@ abbr {
 }
 .focus-styles :focus {
   outline: none;
-  box-shadow: 0px 0 0 1px var(--blue-60), 0 0 0 3px var(--transparentBlue);
+  box-shadow: var(--focusOutlineShadow);
 }
 .focus-styles ::-moz-focus-inner {
   border: 0;

--- a/src/App.vue
+++ b/src/App.vue
@@ -211,13 +211,13 @@ abbr {
 }
 
 :focus {
-  outline: none;
+  outline: 1px solid transparent;
 }
 ::-moz-focus-inner {
   border: 0;
 }
 .focus-styles :focus {
-  outline: none;
+  outline: 1px solid transparent;
   box-shadow: var(--focusOutlineShadow);
 }
 .focus-styles ::-moz-focus-inner {

--- a/src/components/_functional/ShowMore.vue
+++ b/src/components/_functional/ShowMore.vue
@@ -44,6 +44,7 @@
         v-if="isExpanded"
         tabindex="-1"
         ref="overflowContentElement"
+        @keyup.esc="toggleOverflow"
       >
         <slot name="overflow"> </slot>
       </div>

--- a/src/components/_functional/ShowMore.vue
+++ b/src/components/_functional/ShowMore.vue
@@ -83,11 +83,13 @@ export default {
       this.isExpanded = !this.isExpanded;
     },
     handleDocumentClick(event) {
-      if (this.$refs.button.contains(event.target)) {
+      if (this.$refs.button && this.$refs.button.contains(event.target)) {
         event.stopPropagation();
         return;
       }
-      const expandedEl = this.$refs.overflowContentElement.firstElementChild;
+      const expandedEl = this.$refs.overflowContentElement
+        ? this.$refs.overflowContentElement.firstElementChild
+        : null;
 
       // closes overflow content if clicked anywhere, except the
       // overflowing content itself

--- a/src/components/profile/edit/EditPictureModal.vue
+++ b/src/components/profile/edit/EditPictureModal.vue
@@ -155,7 +155,7 @@ export default {
   justify-content: center;
 }
 .focus-styles .edit-picture-modal__add-picture-button:focus-within {
-  box-shadow: 0px 0 0 1px var(--blue-60), 0 0 0 3px var(--transparentBlue);
+  box-shadow: var(--focusOutlineShadow);
 }
 .edit-picture-modal__privacy {
   display: flex;

--- a/src/components/ui/Checkbox.vue
+++ b/src/components/ui/Checkbox.vue
@@ -50,7 +50,7 @@ export default {
   left: 0;
 }
 .focus-styles .checkbox input:focus + svg {
-  box-shadow: 0px 0 0 1px var(--blue-60), 0 0 0 3px var(--transparentBlue);
+  box-shadow: var(--focusOutlineShadow);
 }
 .checkbox input:checked + svg {
   color: var(--blue-60);

--- a/src/components/ui/ContactMe.vue
+++ b/src/components/ui/ContactMe.vue
@@ -157,6 +157,9 @@ export default {
 .contact-me__pair:focus {
   z-index: var(--layerOne);
 }
+.focus-styles .contact-me__pair:focus .contact-me__value {
+  box-shadow: var(--focusOutlineShadow);
+}
 .contact-me__key {
   flex: none;
   width: 30%;

--- a/src/components/ui/Person.vue
+++ b/src/components/ui/Person.vue
@@ -78,7 +78,7 @@ export default {
   box-shadow: none;
 }
 .focus-styles .person a:focus::after {
-  box-shadow: 0px 0 0 1px var(--blue-60), 0 0 0 3px var(--transparentBlue);
+  box-shadow: var(--focusOutlineShadow);
 }
 .person__preferred-title {
   color: var(--gray-50);

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -24,6 +24,7 @@
     <Popover v-if="open">
       <fieldset
         @keydown.enter.prevent="closeList"
+        @keydown.esc="closeList"
         :id="`option-list-${id}`"
         :ref="`optionList-${id}`"
         class="options__list"

--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -229,6 +229,6 @@ export default {
 .focus-styles .options input:focus + label {
   position: relative;
   z-index: var(--layerTwo);
-  box-shadow: 0px 0 0 1px var(--blue-60), 0 0 0 3px var(--transparentBlue);
+  box-shadow: var(--focusOutlineShadow);
 }
 </style>


### PR DESCRIPTION
This fixes a couple of things for keyboard users:

* we use outline of `none`, change to `transparent` (because our replacement, `box-shadow`, [does not work in high contrast mode](https://twitter.com/alastc/status/1125681225828589569))
* use a var for the focus outline shadow and reuse that
* close `Select` and `ContactMe` on ESC