### PR TITLE
Fix mobile search double focus (DP-386)

### DIFF
--- a/src/components/ui/SearchForm.vue
+++ b/src/components/ui/SearchForm.vue
@@ -1,6 +1,6 @@
 <template>
   <form
-    :class="'search-form' + (modifier ? ' ' + modifier : '')"
+    class="search-form"
     :action="
       this.$router.resolve({ name: 'Search', query: { query, who } }).href
     "
@@ -66,9 +66,6 @@
 <script>
 export default {
   name: 'SearchForm',
-  props: {
-    modifier: String,
-  },
   methods: {
     handleSubmit(event) {
       event.preventDefault();

--- a/src/components/ui/TopBar.vue
+++ b/src/components/ui/TopBar.vue
@@ -19,7 +19,7 @@
       >
         <template slot="overflow">
           <SearchForm
-            modifier="search-form--small hide-desktop"
+            class="search-form--small hide-desktop"
             id="mobile-search"
             v-on:close-search-form="closeMobileSearchForm()"
           ></SearchForm>
@@ -89,7 +89,7 @@
       ></Toast>
     </div>
     <SearchForm
-      modifier="search-form--small hide-desktop"
+      class="search-form--small hide-desktop"
       v-if="mobileSearchOpen"
       id="mobile-search"
       v-on:close-search-form="closeMobileSearchForm()"

--- a/src/components/ui/TopBar.vue
+++ b/src/components/ui/TopBar.vue
@@ -15,6 +15,7 @@
         :closeWhenClickedOutside="true"
         ref="showMoreSearch"
         :buttonTextVisuallyHidden="true"
+        :moveFocus="false"
       >
         <template slot="overflow">
           <SearchForm


### PR DESCRIPTION
I believe this was the root cause of DP-386: _focus was set twice_ (first on `input`, then on `div`). This PR fixes this, it is now only set once (just on `input`), by turning off `ShowMore`'s focus moving mechanism for this instance.

Also removes `modifier` prop on `SearchForm`, now sets extra classnames using built-in `class` prop (I wasn't aware that this works when I built `SearchForm`).