### PR TITLE
Make contact me less wide (DP-1267)

### DIFF
--- a/src/components/ui/ContactMe.vue
+++ b/src/components/ui/ContactMe.vue
@@ -12,7 +12,11 @@
     :updateIndicator="primaryEmail"
   >
     <template slot="overflow">
-      <Popover class="contact-me" layer="var(--layerContactMe)" maxWidth="310">
+      <Popover
+        class="contact-me"
+        layer="var(--layerContactMe)"
+        initialMaxWidth="310"
+      >
         <div class="contact-me__item">
           <a :href="`mailto:${primaryEmail}`" class="contact-me__pair">
             <Icon id="at-sign" :width="24" :height="24" />

--- a/src/components/ui/ContactMe.vue
+++ b/src/components/ui/ContactMe.vue
@@ -12,7 +12,7 @@
     :updateIndicator="primaryEmail"
   >
     <template slot="overflow">
-      <Popover class="contact-me" layer="var(--layerContactMe)">
+      <Popover class="contact-me" layer="var(--layerContactMe)" maxWidth="310">
         <div class="contact-me__item">
           <a :href="`mailto:${primaryEmail}`" class="contact-me__pair">
             <Icon id="at-sign" :width="24" :height="24" />

--- a/src/components/ui/Popover.vue
+++ b/src/components/ui/Popover.vue
@@ -11,7 +11,7 @@ export default {
   name: 'Popover',
   props: {
     layer: String,
-    maxWidth: {
+    initialMaxWidth: {
       type: Number,
       default: 350,
     },
@@ -55,6 +55,7 @@ export default {
   data() {
     return {
       position: '',
+      maxWidth: this.initialMaxWidth,
     };
   },
   mounted() {

--- a/src/components/ui/Popover.vue
+++ b/src/components/ui/Popover.vue
@@ -11,6 +11,10 @@ export default {
   name: 'Popover',
   props: {
     layer: String,
+    maxWidth: {
+      type: Number,
+      default: 350,
+    },
   },
   methods: {
     positionAndSize() {
@@ -51,7 +55,6 @@ export default {
   data() {
     return {
       position: '',
-      maxWidth: 350,
     };
   },
   mounted() {


### PR DESCRIPTION
I've made `maxWidth` for the popover a prop so that we can change it based on where it is used.

This sets a smaller `maxWidth` for the `ContactMe` popover, as we need less space now that we no longer display user names.