### PR TITLE
Fix regression bug in custom select

### DIFF
--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -218,13 +218,13 @@ export default {
   position: absolute;
   opacity: 0;
 }
-.options label {
+.options li > label {
   padding: 0.75em 0.5em 0.75em 1em;
   margin: 0;
   display: flex;
   align-items: center;
 }
-.options label:hover {
+.options li > label:hover {
   background-color: var(--lightBlue);
 }
 .focus-styles .options input:focus + label {


### PR DESCRIPTION
A regression happened when I made the label styles more specific (using `.mutation-form label`, so that the one style works in all mutation forms): it set all `label`s to `display: block`, but the labels in our custom select need to be `display: flex;`. This increases specificity, while, I think, still acceptable.

Before (currently on prod): 

<img width="395" alt="dropdown with check icon in wrong place" src="https://user-images.githubusercontent.com/178782/57929915-e3096180-78b4-11e9-9434-e2c32302294a.png">

After: 

<img width="400" alt="same dropdown with check icon aligned right" src="https://user-images.githubusercontent.com/178782/57929938-f3b9d780-78b4-11e9-80ac-61d5a6f38cd7.png">
