### PR TITLE
auto-close user menu when links are clicked while still following links

### DIFF
--- a/src/components/_functional/ShowMore.vue
+++ b/src/components/_functional/ShowMore.vue
@@ -60,7 +60,6 @@ export default {
     alternateButtonText: String,
     buttonClass: String,
     transition: Boolean,
-    expanded: Boolean,
     closeWhenClickedOutside: {
       type: Boolean,
       default: false,
@@ -103,20 +102,20 @@ export default {
       }
 
       // if clicked on a link or button anywhere, close the overflow content
+      // a delay is needed since otherwise links aren't followed
       if (event.target.tagName === 'A' || event.target.tagName === 'BUTTON') {
-        this.isExpanded = false;
+        setTimeout(() => {
+          this.isExpanded = false;
+        }, 500);
       }
     },
   },
   data() {
     return {
-      isExpanded: this.expanded,
+      isExpanded: false,
     };
   },
   watch: {
-    expanded() {
-      this.isExpanded = this.expanded;
-    },
     updateIndicator(val, old) {
       if (this.closeOnUpdate && old && old !== val) {
         this.isExpanded = false;

--- a/src/components/profile/view/ViewPersonalInfo.vue
+++ b/src/components/profile/view/ViewPersonalInfo.vue
@@ -54,7 +54,6 @@
         v-if="this.staffInformation.staff.value"
         buttonText="Show More"
         alternateButtonText="Show Less"
-        :expanded="false"
         buttonClass="button button--text-only button--less-padding"
         :transition="true"
       >

--- a/src/components/ui/ContactMe.vue
+++ b/src/components/ui/ContactMe.vue
@@ -2,7 +2,6 @@
   <ShowMore
     buttonText="Contact Me"
     alternateButtonText="Contact Me"
-    :expanded="false"
     buttonClass="button button--icon-end contact-me__button"
     :transition="false"
     :closeWhenClickedOutside="true"

--- a/src/components/ui/Tooltip.vue
+++ b/src/components/ui/Tooltip.vue
@@ -5,7 +5,6 @@
     buttonClass="button button--icon-only"
     :alternateButtonText="alternateButtonText"
     :closeWhenClickedOutside="true"
-    :expanded="false"
     :buttonTextVisuallyHidden="true"
   >
     <template slot="overflow">

--- a/src/components/ui/TopBar.vue
+++ b/src/components/ui/TopBar.vue
@@ -11,7 +11,6 @@
         buttonText="Open search"
         alternateButtonText="Close search"
         buttonClass="hide-desktop top-bar__search-toggle"
-        :expanded="false"
         :closeWhenClickedOutside="true"
         ref="showMoreSearch"
         :buttonTextVisuallyHidden="true"
@@ -60,9 +59,6 @@
           buttonText="Open user menu"
           alternateButtonText="Close user menu"
           buttonClass="top-bar__user-menu-toggle"
-          :expanded="false"
-          @close-user-menu="closeUserMenu"
-          ref="showMoreUserMenu"
           :closeWhenClickedOutside="true"
           :buttonTextVisuallyHidden="true"
         >
@@ -90,7 +86,7 @@
     </div>
     <SearchForm
       class="search-form--small hide-desktop"
-      v-if="mobileSearchOpen"
+      v-if="showMobileSearch"
       id="mobile-search"
       v-on:close-search-form="closeMobileSearchForm()"
     ></SearchForm>
@@ -114,11 +110,8 @@ export default {
     UserPicture,
   },
   methods: {
-    closeUserMenu() {
-      this.$refs.showMoreUserMenu.isExpanded = false;
-    },
     closeMobileSearchForm() {
-      this.$refs.showMoreSearch.isExpanded = false;
+      this.showMobileSearch = false;
     },
     showToast(data) {
       this.toastContent = data.content;
@@ -126,7 +119,7 @@ export default {
   },
   data() {
     return {
-      mobileSearchOpen: false,
+      showMobileSearch: false,
       showBanner: true,
       extraPadding: 0,
       toastContent: '',

--- a/src/components/ui/UserMenu.vue
+++ b/src/components/ui/UserMenu.vue
@@ -1,11 +1,7 @@
 <template>
   <div class="user-menu" ref="userMenuEl">
     <div class="user-menu__header">
-      <button
-        class="user-menu__close-avatar"
-        type="button"
-        @click="sendCloseEvent()"
-      >
+      <button class="user-menu__close-avatar" type="button">
         <span class="visually-hidden">Close user menu</span>
         <UserPicture
           :picture="user.picture.value"
@@ -32,7 +28,6 @@
         class="user-menu__close-button"
         id="user-menu-close-button"
         type="button"
-        @click="sendCloseEvent()"
       >
         <svg
           xmlns="http://www.w3.org/2000/svg"
@@ -53,7 +48,7 @@
         </svg>
       </button>
     </div>
-    <ul class="user-menu__items" @click="closeOnLinkClick">
+    <ul class="user-menu__items">
       <li>
         <RouterLink
           id="link-usermenu-my-profile"
@@ -103,16 +98,6 @@ import UserPicture from './UserPicture.vue';
 
 export default {
   name: 'UserMenu',
-  methods: {
-    sendCloseEvent() {
-      this.$parent.$emit('close-user-menu');
-    },
-    closeOnLinkClick(e) {
-      if (e.target.tagName === 'A') {
-        this.$parent.$emit('close-user-menu');
-      }
-    },
-  },
   mounted() {
     if (matchMedia('(min-width: 50em)').matches === false) {
       Modal.methods.preventBackgroundScrolling();


### PR DESCRIPTION
@fiji-flo I'm not happy with this just yet, I'm still using a timeout as links aren't followed for some reason when the menu closes immediately. The click/touch event is listenning in the bubble phase which should mean that the menu is closed after the link was opened, shouldn't it? I'm a little puzzled by this.
The timeout does the job but it's a dirty hack and who knows how it behaves on slow devices :/

@hidde there was some anti-patterning going on here, where the `TopBar` was setting state for its child `ShowMore` components. Data should only flow through props from Parent to Child. In this case I didn't find out the exact reasoning behind it, as `ShowMore` controlled its own state in all instances, so maybe just a relic of the past. Please LMK if I missed sth here.