### PR TITLE
Use apolloProvider directly

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -83,7 +83,7 @@ const store = new Vuex.Store({
 store.dispatch('fetchUser').then(() => {
   new Vue({
     router,
-    provide: apolloProvider.provide(),
+    apolloProvider,
     render: (h) => h(App),
     store,
   }).$mount('#app');


### PR DESCRIPTION
We've had this console error for ages: 

```<ApolloProvider>.provide() is deprecated. Use the 'apolloProvider' option instead with the provider object directly.``` 

This addresses that.