### PR TITLE
Only show one key initially (DP-1330)

### DIFF
--- a/src/components/profile/view/ViewKeys.vue
+++ b/src/components/profile/view/ViewKeys.vue
@@ -24,8 +24,8 @@
       />
       <ShowMore
         v-if="Object.entries(pgpPublicKeys.values).length > this.initiallyShown"
-        buttonText="Show More PGP Keys"
-        alternateButtonText="Show Less PGP Keys"
+        buttonText="Show More"
+        alternateButtonText="Show Less"
         class="keys__show-more"
         buttonClass="button button--text-only button--less-padding keys__show-more-button"
         :transition="true"
@@ -65,8 +65,8 @@
       />
       <ShowMore
         v-if="Object.entries(sshPublicKeys.values).length > this.initiallyShown"
-        buttonText="Show More SSH Keys"
-        alternateButtonText="Show Less SSH Keys"
+        buttonText="Show More"
+        alternateButtonText="Show Less"
         class="keys__show-more"
         buttonClass="button button--text-only button--less-padding keys__show-more-button"
         :transition="true"

--- a/src/components/profile/view/ViewKeys.vue
+++ b/src/components/profile/view/ViewKeys.vue
@@ -13,12 +13,41 @@
     >
       <h4 class="visually-hidden">PGP</h4>
       <Key
-        v-for="[key, value] in Object.entries(pgpPublicKeys.values)"
+        v-for="[key, value] in Object.entries(pgpPublicKeys.values).slice(
+          0,
+          this.initiallyShown,
+        )"
         type="PGP"
         :title="key"
         :content="value"
         :key="`pgp-${key}`"
       />
+      <ShowMore
+        v-if="Object.entries(pgpPublicKeys.values).length > this.initiallyShown"
+        buttonText="Show More PGP Keys"
+        alternateButtonText="Show Less PGP Keys"
+        class="keys__show-more"
+        buttonClass="button button--text-only button--less-padding keys__show-more-button"
+        :transition="true"
+      >
+        <template slot="overflow">
+          <Key
+            v-for="[key, value] in Object.entries(pgpPublicKeys.values).slice(
+              this.initiallyShown,
+            )"
+            type="PGP"
+            :title="key"
+            :content="value"
+            :key="`pgp-${key}`"
+          />
+        </template>
+        <template slot="icon-expanded">
+          <Icon id="chevron-up" :width="24" :height="24" />
+        </template>
+        <template slot="icon-collapsed">
+          <Icon id="chevron-down" :width="24" :height="24" />
+        </template>
+      </ShowMore>
     </template>
     <template
       v-if="sshPublicKeys && Object.keys(sshPublicKeys.values).length > 0"

--- a/src/components/profile/view/ViewKeys.vue
+++ b/src/components/profile/view/ViewKeys.vue
@@ -25,19 +25,50 @@
     >
       <h4 class="visually-hidden">SSH</h4>
       <Key
-        v-for="[key, value] in Object.entries(sshPublicKeys.values)"
+        v-for="[key, value] in Object.entries(sshPublicKeys.values).slice(
+          0,
+          this.initiallyShown,
+        )"
         type="SSH"
         :title="key"
         :content="value"
         :key="`ssh-${key}`"
       />
+      <ShowMore
+        v-if="Object.entries(sshPublicKeys.values).length > this.initiallyShown"
+        buttonText="Show More SSH Keys"
+        alternateButtonText="Show Less SSH Keys"
+        class="keys__show-more"
+        buttonClass="button button--text-only button--less-padding keys__show-more-button"
+        :transition="true"
+      >
+        <template slot="overflow">
+          <Key
+            v-for="[key, value] in Object.entries(sshPublicKeys.values).slice(
+              this.initiallyShown,
+            )"
+            type="SSH"
+            :title="key"
+            :content="value"
+            :key="`ssh-${key}`"
+          />
+        </template>
+        <template slot="icon-expanded">
+          <Icon id="chevron-up" :width="24" :height="24" />
+        </template>
+        <template slot="icon-collapsed">
+          <Icon id="chevron-down" :width="24" :height="24" />
+        </template>
+      </ShowMore>
     </template>
   </div>
 </template>
 
 <script>
 import EditButton from '@/components/profile/edit/EditButton.vue';
+import Icon from '@/components/ui/Icon.vue';
 import Key from '@/components/ui/Key.vue';
+import ShowMore from '@/components/_functional/ShowMore.vue';
 
 export default {
   name: 'ViewKeys',
@@ -48,7 +79,25 @@ export default {
   },
   components: {
     EditButton,
+    Icon,
     Key,
+    ShowMore,
+  },
+  data() {
+    return {
+      initiallyShown: 1,
+    };
   },
 };
 </script>
+
+<style>
+.keys__show-more {
+  padding: 0.5em 0;
+}
+.keys__show-more-button {
+  font-size: 1em;
+  margin: 0 auto;
+  color: var(--gray-50);
+}
+</style>


### PR DESCRIPTION
This adds a `ShowMore` to PGP/SSH keys, only showing one initially, and the rest after clicking ‘Show More’