### PR TITLE
Update relation/org chart toggle hovers (DP-1245)

### DIFF
--- a/src/components/profile/ReportingStructure.vue
+++ b/src/components/profile/ReportingStructure.vue
@@ -35,7 +35,7 @@
               v-for="(direct, index) in this.related.directs.slice(
                 this.initiallyShown,
               )"
-              :modifier="directsView"
+              :class="directsView"
               :key="`direct-${index}`"
               v-bind="direct"
             />

--- a/src/components/profile/view/ViewColleagues.vue
+++ b/src/components/profile/view/ViewColleagues.vue
@@ -100,7 +100,7 @@ export default {
   border-bottom-right-radius: var(--imageRadius);
 }
 .colleagues__toggle-button:not(.colleagues__toggle-button--current):hover {
-  background-color: var(--gray-30);
+  background-color: var(--gray-20);
 }
 .colleagues__toggle-button:focus {
   position: relative;

--- a/src/pages/PageOrgchart.vue
+++ b/src/pages/PageOrgchart.vue
@@ -305,8 +305,9 @@ export default {
   height: 2.5em;
 }
 .org-chart-buttons__control:hover {
-  background-color: var(--blue-30);
+  background-color: var(--blue-60);
   border: 2px solid var(--gray-30);
+  color: var(--white);
 }
 .org-chart-buttons__control > svg {
   margin: auto;

--- a/src/pages/PageOrgchart.vue
+++ b/src/pages/PageOrgchart.vue
@@ -305,9 +305,8 @@ export default {
   height: 2.5em;
 }
 .org-chart-buttons__control:hover {
-  background-color: var(--blue-60);
+  background-color: var(--blue-30);
   border: 2px solid var(--gray-30);
-  color: var(--white);
 }
 .org-chart-buttons__control > svg {
   margin: auto;


### PR DESCRIPTION
Ensure that the hovers on toggles (for relations and for org chart) match the border color, as per @mbransn's comment in DP-1245..

This also fixes a regression in the colleagues section where the items inside `ShowMore` look weird.