### PR TITLE
Address word wrapping better to avoid layout breakage (DP-1359, DP-1363)

### DIFF
--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -484,6 +484,11 @@ export default {
 </script>
 
 <style>
+.profile {
+  word-break: break-word;
+  word-wrap: anywhere; /* non-standard, but wide browser support, standardised as overflow-wrap */
+  overflow-wrap: anywhere; /* standard, less browser support */
+}
 @media (min-width: 57.5em) {
   .profile {
     display: grid;

--- a/src/components/profile/view/ViewPersonalInfo.vue
+++ b/src/components/profile/view/ViewPersonalInfo.vue
@@ -150,7 +150,6 @@ export default {
   position: relative;
   padding-top: 5em;
   margin-top: 5em;
-  word-wrap: anywhere;
 }
 @media (min-width: 57.5em) {
   .profile__intro {


### PR DESCRIPTION
There were two issues (DP-1359, DP-1363) caused by someone having a very long string as first name / pronoun. Because such strings did not get wrapped (in Chrome), the boxes grew, which broke the lay-out.

Fixed by allowing word-wrap globally on the profile.

For maximum browser support, it uses 3 properties: `word-break` (not in IE/Edge yet), `word-wrap` (non-standard, works in IE/Edge/Firefox. not Chrome) and `overflow-wrap` (standard, not in IE/Edge/Chrome yet).