### PR TITLE
Improve colleagues on mobile (DP-1245)

### DIFF
--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -540,9 +540,17 @@ export default {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  flex-wrap: wrap;
 }
 .profile__section-header h2 {
-  margin: 0;
+  margin: 0 0 0.75em 0;
+  width: 100%;
+}
+@media (min-width: 35em) {
+  .profile__section-header h2 {
+    margin: 0;
+    width: auto;
+  }
 }
 
 .profile__anchor {

--- a/src/components/profile/ReportingStructure.vue
+++ b/src/components/profile/ReportingStructure.vue
@@ -125,6 +125,9 @@ export default {
     grid-gap: 2em;
     grid-template-columns: 6em 1fr;
   }
+  .reporting-structure__manages > div {
+    min-width: 0; /* defaults to auto, which allows people's name/title to grow the grid column */
+  }
 }
 .reporting-structure__show-more {
   max-width: 37.5em;

--- a/src/components/ui/Person.vue
+++ b/src/components/ui/Person.vue
@@ -59,6 +59,12 @@ export default {
 .person__name {
   font-weight: 700;
 }
+.person__name,
+.person__preferred-title {
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+}
 .person a {
   color: inherit;
   text-decoration: none;

--- a/src/components/ui/Person.vue
+++ b/src/components/ui/Person.vue
@@ -124,6 +124,7 @@ export default {
 .person--borderless .user-picture {
   align-self: center;
   margin-right: 1em;
+  flex: none;
 }
 .person--avatar-only {
   display: inline-block;


### PR DESCRIPTION
* user pictures were shrinking because they were flex items; set flex to none to avoid, as we always want them to be square
* force name and job title to be on one line with … if needed
* force header controls (like list/grid view on colleagues header) to next line on small screens
* reset min-width for column with people in it (defaults to `auto`, which would allow people with very long names/titles to stretch column size)

(This is like https://github.com/mozilla-iam/dino-park-front-end/pull/373 minus the solution for showing only first line of avatars)