### PR TITLE
Let people add their Zoom Personal Meeting ID, recategorise IRC

### DIFF
--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -1,5 +1,5 @@
 <script>
-const ENABLED_ACCOUNTS = ['DISCOURSE', 'IRC', 'SLACK'];
+const ENABLED_ACCOUNTS = ['DISCOURSE', 'IRC', 'SLACK', 'ZOOM'];
 const EXTERNAL_ACCOUNTS = {
   AIM: { moz: false, text: 'AIM', icon: 'aim' },
   BITBUCKET: { moz: false, text: 'Bitbucket', icon: 'bitbucket' },
@@ -52,12 +52,19 @@ const EXTERNAL_ACCOUNTS = {
   YAHOO: { moz: false, text: 'Yahoo! Messenger', icon: 'yahoo' },
   IRC: { moz: true, text: 'IRC', icon: 'irc' },
   SLACK: { moz: true, text: 'Mozilla Slack', icon: 'slack' },
+  ZOOM: {
+    moz: true,
+    text: 'Mozilla Zoom',
+    icon: 'zoom',
+    placeholder: 'Your Personal Meeting ID',
+    uri: 'https://mozilla.zoom.us/j/@@@',
+  },
 };
 
 export default {
   methods: {
     account([key, value]) {
-      const { moz, text, icon } = EXTERNAL_ACCOUNTS[key] || {};
+      const { moz, text, icon, placeholder } = EXTERNAL_ACCOUNTS[key] || {};
       let { uri } = EXTERNAL_ACCOUNTS[key] || { uri: null };
 
       if (uri) {
@@ -69,6 +76,7 @@ export default {
           moz,
           text,
           icon,
+          placeholder,
           value,
           uri,
         };

--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -50,7 +50,7 @@ const EXTERNAL_ACCOUNTS = {
   WEBSITE: { moz: false, text: 'Website URL', icon: 'website' },
   JABBER: { moz: false, text: 'XMPP/Jabber', icon: 'jabber' },
   YAHOO: { moz: false, text: 'Yahoo! Messenger', icon: 'yahoo' },
-  IRC: { moz: false, text: 'IRC', icon: 'irc' },
+  IRC: { moz: true, text: 'IRC', icon: 'irc' },
   SLACK: { moz: true, text: 'Mozilla Slack', icon: 'slack' },
 };
 

--- a/src/components/profile/edit/EditAccounts.vue
+++ b/src/components/profile/edit/EditAccounts.vue
@@ -45,7 +45,8 @@
         type="text"
         v-model="uris.values[index].v"
         :placeholder="
-          `Your username on ${EXTERNAL_ACCOUNTS[destructUriKey(k).name].text}`
+          EXTERNAL_ACCOUNTS[destructUriKey(k).name].placeholder ||
+            `Your username on ${EXTERNAL_ACCOUNTS[destructUriKey(k).name].text}`
         "
       />
       <Checkbox

--- a/src/components/ui/Icon.vue
+++ b/src/components/ui/Icon.vue
@@ -439,6 +439,18 @@
         <line x1="21" y1="18" x2="3" y2="18" />
       </g>
     </template>
+    <template v-else-if="id === 'zoom'">
+      <polygon fill="currentColor" points="23 7 16 12 23 17 23 7" />
+      <rect
+        fill="currentColor"
+        x="1"
+        y="5"
+        width="15"
+        height="14"
+        rx="2"
+        ry="2"
+      />
+    </template>
   </svg>
 </template>
 


### PR DESCRIPTION
## Zoom

* Added provisional Zoom icon (cc @mbransn, this is the camera icon from the Feather icon set)
* Added new thing to account objects: 'placeholder'. This is used to override the placeholder/suggestion when adding a new account. Now useful for Zoom, potentially useful to others in the future
* Added Zoom as an enabled account

## IRC 

* Categorise IRC under ‘Mozilla’,  fixes https://github.com/mozilla-iam/dino-park-issues/issues/81 