### PR TITLE
feat(dino-park): making slack be the default account

### DIFF
--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -94,7 +94,7 @@ export default {
   data() {
     return {
       availableAccounts: ENABLED_ACCOUNTS.filter(
-        (account) => Object.keys(EXTERNAL_ACCOUNTS).indexOf(account) !== -1,
+        (account) => account in EXTERNAL_ACCOUNTS,
       ),
       EXTERNAL_ACCOUNTS,
     };

--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -1,5 +1,5 @@
 <script>
-const ENABLED_ACCOUNTS = ['DISCOURSE', 'IRC', 'SLACK', 'ZOOM'];
+const ENABLED_ACCOUNTS = ['SLACK', 'DISCOURSE', 'IRC', 'ZOOM'];
 const EXTERNAL_ACCOUNTS = {
   AIM: { moz: false, text: 'AIM', icon: 'aim' },
   BITBUCKET: { moz: false, text: 'Bitbucket', icon: 'bitbucket' },
@@ -93,8 +93,8 @@ export default {
   },
   data() {
     return {
-      availableAccounts: [...Object.keys(EXTERNAL_ACCOUNTS)].filter((account) =>
-        ENABLED_ACCOUNTS.includes(account),
+      availableAccounts: ENABLED_ACCOUNTS.filter(
+        (account) => Object.keys(EXTERNAL_ACCOUNTS).indexOf(account) !== -1,
       ),
       EXTERNAL_ACCOUNTS,
     };


### PR DESCRIPTION
Updating AccountsMixin to feed list of accounts from 'ENABLED_ACCOUNTS' rather than 'EXTERNAL_ACCOUNTS' in order to maintain specific list order and default value.