### PR TITLE
fix(dino-park): adjusting account order

### DIFF
--- a/src/components/_mixins/AccountsMixin.vue
+++ b/src/components/_mixins/AccountsMixin.vue
@@ -1,5 +1,5 @@
 <script>
-const ENABLED_ACCOUNTS = ['SLACK', 'DISCOURSE', 'IRC', 'ZOOM'];
+const ENABLED_ACCOUNTS = ['SLACK', 'ZOOM', 'DISCOURSE', 'IRC'];
 const EXTERNAL_ACCOUNTS = {
   AIM: { moz: false, text: 'AIM', icon: 'aim' },
   BITBUCKET: { moz: false, text: 'Bitbucket', icon: 'bitbucket' },


### PR DESCRIPTION
There was one more comment from @HerminaC in the story https://jira.mozilla.com/browse/DP-1425 that I missed about re-ordering the account list:
SLACK, ZOOM, DISCOURSE, IRC

Jira: https://jira.mozilla.com/browse/DP-1425
