### PR TITLE
use srcset for user pictures

### DIFF
--- a/src/components/ui/TopBar.vue
+++ b/src/components/ui/TopBar.vue
@@ -77,7 +77,6 @@
                 username: user.primaryUsername.value,
               }"
               :size="40"
-              :pictureSize="100"
               dinoType="Staff"
             ></UserPicture>
           </template>

--- a/src/components/ui/UserMenu.vue
+++ b/src/components/ui/UserMenu.vue
@@ -9,7 +9,6 @@
             username: user.primaryUsername.value,
           }"
           :size="40"
-          :pictureSize="100"
         ></UserPicture>
       </button>
       <div class="user-menu__name">

--- a/src/components/ui/UserPicture.vue
+++ b/src/components/ui/UserPicture.vue
@@ -80,13 +80,12 @@ export default {
       }
     },
     buildSrcset() {
+      if (!this.slot) return '';
       return [40, 100, 264]
-        .map(
-          (s) =>
-            `${this.avatar.picture}?size=${s} ${(s / this.slot).toPrecision(
-              2,
-            )}x`,
-        )
+        .map((s) => {
+          const res = (s / this.slot).toPrecision(2);
+          return `${this.avatar.picture}?size=${s} ${res}x`;
+        })
         .join(' ');
     },
   },

--- a/src/components/ui/UserPicture.vue
+++ b/src/components/ui/UserPicture.vue
@@ -5,6 +5,7 @@
       ref="img"
       :class="cls"
       :src="src"
+      :srcset="srcset"
       alt=""
       :width="size"
       role="presentation"
@@ -29,7 +30,6 @@ export default {
       },
     },
     cls: String,
-    pictureSize: Number,
     isStaff: Boolean,
   },
   components: {
@@ -56,7 +56,6 @@ export default {
         this.dinoTypeSize = 'large';
         this.slot = 264;
       }
-      this.slot = this.pictureSize || this.slot;
       this.modifier = `user-picture--${this.dinoTypeSize}`;
     },
     async updateUserPicture() {
@@ -77,7 +76,18 @@ export default {
         this.src = await generateIdenticon(this.avatar.username, this.size);
       } else {
         this.src = `${this.avatar.picture}?size=${this.slot}`;
+        this.srcset = this.buildSrcset();
       }
+    },
+    buildSrcset() {
+      return [40, 100, 264]
+        .map(
+          (s) =>
+            `${this.avatar.picture}?size=${s} ${(s / this.slot).toPrecision(
+              2,
+            )}x`,
+        )
+        .join(' ');
     },
   },
   created() {
@@ -86,6 +96,7 @@ export default {
   data() {
     return {
       src: '',
+      srcset: '',
       dinoTypeSize: 'small',
       slot: 40,
       class: 'user-picture--40',


### PR DESCRIPTION
Testing in Firefox using `layout.css.devPixelsPerPx` suggests Firefox prefers to downscale a higher resolution image than upscale a lower resolution one (which is what we want).

Running `layout.css.devPixelsPerPx` at 2.6x for instance, loads the 264px avatar in the 40px slot even through 100/40px is closer (at 2.5x).

528px not yet included as Firefox doesn't discard 404ing images and use a lower resolution instead, so we need to finish/deploy the changes on the backend first.