### PR TITLE
fix: changing arrow to explicit function to make vue dev tools work

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -98,7 +98,7 @@ const store = new Vuex.Store({
   },
 });
 
-store.dispatch('fetchUser').then(() => {
+store.dispatch('fetchUser').then(function() {
   new Vue({
     router,
     apolloProvider,


### PR DESCRIPTION
After trying to make Firefox DevTools: Vue tab work for our application, I found out that this is just because of an arrow function use that we don't get that inspector in our dev tools. This one liner will allow us to use the Vue tab in dev tools.