### PR TITLE
fix search and orgchart for non-staff

### DIFF
--- a/src/components/search/SearchResult.vue
+++ b/src/components/search/SearchResult.vue
@@ -10,11 +10,11 @@
       :to="{ name: 'Profile', params: { username: username } }"
       class="search-result__profile-link"
     >
-      <div class="search-result__name">{{ firstName }} {{ lastName }}</div>
+      <div class="search-result__name">{{ displayName }}</div>
       <div class="search-result__title">{{ title || funTitle }}</div>
     </RouterLink>
     <RouterLink
-      v-if="scope.isStaff"
+      v-if="scope.isStaff && isStaff"
       :to="{ name: 'OrgchartHighlight', params: { username: username } }"
       class="search-result__orgchart-link"
     >
@@ -55,6 +55,17 @@ export default {
   },
   components: {
     UserPicture,
+  },
+  computed: {
+    displayName() {
+      if (this.firstName || this.lastName) {
+        return `${this.firstName} ${this.lastName}`;
+      }
+      if (!this.username.startsWith('r--')) {
+        return this.username;
+      }
+      return 'Anonymous User';
+    },
   },
 };
 </script>

--- a/src/components/search/SearchResult.vue
+++ b/src/components/search/SearchResult.vue
@@ -58,8 +58,14 @@ export default {
   },
   computed: {
     displayName() {
-      if (this.firstName || this.lastName) {
+      if (this.firstName && this.lastName) {
         return `${this.firstName} ${this.lastName}`;
+      }
+      if (this.firstName) {
+        return this.firstName;
+      }
+      if (this.lastName) {
+        return this.lastName;
       }
       if (!this.username.startsWith('r--')) {
         return this.username;

--- a/src/pages/PageOrgchart.vue
+++ b/src/pages/PageOrgchart.vue
@@ -31,7 +31,9 @@
       </button>
     </div>
     <div class="org-chart">
-      <div class="org-chart__chart"><LoadingSpinner></LoadingSpinner></div>
+      <div class="org-chart__chart">
+        <LoadingSpinner v-if="loading"></LoadingSpinner>
+      </div>
       <ApolloQuery
         v-if="username && (desktopView || openedFromOrgNode)"
         :query="previewProfileQuery"
@@ -226,6 +228,10 @@ export default {
       this.loading = true;
       try {
         const data = await fetcher.fetch('/api/v4/orgchart');
+        if (data.status === 403) {
+          this.$router.push({ path: '/forbidden' });
+          return;
+        }
         const orgchart = await data.json();
         this.initiallyExpanded = orgchart.forrest
           .map((node) => node.data.username)


### PR DESCRIPTION
- hide orgchart button for non-staff in search results
- fall back to username on empy names
- fall back to 'Anonymous User' for default usernames
- show unknown page if orgchart is forbidden