### PR TITLE
fix(IAM-271): fixing empty message, fixing previewas constants

### DIFF
--- a/src/components/profile/PreviewAs.vue
+++ b/src/components/profile/PreviewAs.vue
@@ -32,14 +32,7 @@
 import Icon from '@/components/ui/Icon.vue';
 import Button from '@/components/ui/Button.vue';
 import Select from '@/components/ui/Select.vue';
-
-const PERMISSIONS = {
-  private: 'PRIVATE',
-  staff: 'STAFF',
-  ndaed: 'NDAED',
-  authenticated: 'AUTHENTICATED',
-  public: 'PUBLIC',
-};
+import { DISPLAY_LEVELS } from '@/assets/js/display-levels';
 
 export default {
   name: 'PreviewAs',
@@ -50,7 +43,7 @@ export default {
   },
   methods: {
     activate() {
-      this.viewAs = this.$route.query.pa || PERMISSIONS.private;
+      this.viewAs = this.$route.query.pa || DISPLAY_LEVELS.private.value;
       this.updateFilter();
     },
 
@@ -79,15 +72,36 @@ export default {
     },
   },
   data() {
-    this.viewAsFilter.filter = this.$route.query.pa || PERMISSIONS.private;
+    this.viewAsFilter.filter =
+      this.$route.query.pa || DISPLAY_LEVELS.private.value;
     return {
       viewAs: this.viewAsFilter.filter,
       viewAsOptions: [
-        { label: 'Myself', value: PERMISSIONS.private, icon: 'avatar' },
-        { label: 'Staff', value: PERMISSIONS.staff, icon: 'staff' },
-        { label: "Ndae'd", value: PERMISSIONS.ndaed, icon: 'triangle' },
-        { label: 'Registered', value: PERMISSIONS.authenticated, icon: 'lock' },
-        { label: 'Public', value: PERMISSIONS.public, icon: 'world' },
+        {
+          label: 'Myself',
+          value: DISPLAY_LEVELS.private.value,
+          icon: 'avatar',
+        },
+        {
+          label: 'Staff',
+          value: DISPLAY_LEVELS.staff.value,
+          icon: DISPLAY_LEVELS.staff.icon,
+        },
+        {
+          label: "Ndae'd",
+          value: DISPLAY_LEVELS.ndaed.value,
+          icon: DISPLAY_LEVELS.ndaed.icon,
+        },
+        {
+          label: 'Registered',
+          value: DISPLAY_LEVELS.authenticated.value,
+          icon: DISPLAY_LEVELS.authenticated.icon,
+        },
+        {
+          label: 'Public',
+          value: DISPLAY_LEVELS.public.value,
+          icon: DISPLAY_LEVELS.public.icon,
+        },
       ],
     };
   },

--- a/src/components/profile/ProfileSection.vue
+++ b/src/components/profile/ProfileSection.vue
@@ -11,7 +11,7 @@
           :sectionId="section"
         ></EditButton>
       </header>
-      <p v-if="empty">{{ userOnOwnProfile ? messageOwn : message }}</p>
+      <p v-if="empty">{{ emptyMessageText }}</p>
       <slot name="view" v-else></slot>
     </template>
   </section>
@@ -20,6 +20,7 @@
 <script>
 import EditButton from '@/components/profile/edit/EditButton.vue';
 import EmptyCard from '@/components/profile/view/EmptyCard.vue';
+import { DISPLAY_LEVELS } from '@/assets/js/display-levels';
 
 export default {
   name: 'ProfileSection',
@@ -47,6 +48,17 @@ export default {
         'profile__section--editing': this.editing,
         'profile__section--disabled': !this.editing && this.empty,
       };
+    },
+    emptyMessageText() {
+      if (
+        !this.userOnOwnProfile ||
+        ![undefined, DISPLAY_LEVELS.private.value].includes(
+          this.$route.query.pa,
+        )
+      ) {
+        return this.message;
+      }
+      return this.messageOwn;
     },
   },
 };


### PR DESCRIPTION
Fixing empty message so that it shows "No {items} have been added" when not viewing as self, and "You have not added {}" when viewing as self.
Also fixing refactor in PreviewAs.vue

Jira Story: https://jira.mozilla.com/browse/IAM-271