### PR TITLE
Setup access groups: changing reload files

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "marked": "^0.7.0",
     "object.pick": "^1.3.0",
     "preact": "^8.4.2",
-    "reload": "^3.0.3",
     "vue": "^2.6.10",
     "vue-apollo": "^3.0.0-beta.28",
     "vue-router": "^3.0.6",

--- a/src/server.js
+++ b/src/server.js
@@ -1,7 +1,7 @@
 import { InMemoryCache, defaultDataIdFromObject } from 'apollo-cache-inmemory';
 import ApolloClient from 'apollo-boost';
 import VueApollo from 'vue-apollo';
-import reload from 'reload';
+import reload from '@/assets/js/reload';
 
 function errorHandler(error) {
   const failoverOn = [302];


### PR DESCRIPTION
Changing reload import to use local reload.js rather than the reload npm library.