### PR TITLE
Going to profile edit page from back button fills edit fields with last opened profile

### DIFF
--- a/src/components/profile/Profile.vue
+++ b/src/components/profile/Profile.vue
@@ -100,11 +100,6 @@
             initialSecondaryEmail1: identities.custom1PrimaryEmail,
             initialSecondaryEmail2: identities.custom2PrimaryEmail,
             initialPhoneNumbers: phoneNumbers,
-            initialValues: {
-              primaryEmail,
-              phoneNumbers,
-              uris,
-            },
           }"
         />
       </template>
@@ -129,7 +124,6 @@
         <EditAccounts
           v-bind="{
             username: primaryUsername.value,
-            initialValues: { uris },
             initialUris: uris,
           }"
         ></EditAccounts>
@@ -153,7 +147,6 @@
         <EditLanguages
           v-bind="{
             username: primaryUsername.value,
-            initialValues: { languages },
             initialLanguages: languages,
           }"
         ></EditLanguages>
@@ -177,7 +170,6 @@
         <EditTags
           v-bind="{
             username: primaryUsername.value,
-            initialValues: { tags },
             initialTags: tags,
           }"
         ></EditTags>

--- a/src/components/profile/edit/EditAccessGroups.vue
+++ b/src/components/profile/edit/EditAccessGroups.vue
@@ -4,7 +4,6 @@
       accessInformationMozilliansorgDisplay: editMozilliansorgGroups.display,
       accessInformationLdapDisplay: editLdapGroups.display,
     }"
-    :initialValues="initialAccessInformation"
     formName="Edit access groups"
   >
     <header class="profile__section-header" ref="header" tabindex="-1">

--- a/src/components/profile/edit/EditAccounts.vue
+++ b/src/components/profile/edit/EditAccounts.vue
@@ -3,7 +3,6 @@
     :editVariables="{
       uris,
     }"
-    :initialValues="initialValues"
     formName="Edit accounts"
   >
     <header class="profile__section-header" ref="header" tabindex="-1">
@@ -87,7 +86,6 @@ export default {
         return {};
       },
     },
-    initialValues: Object,
     editVariables: Object,
   },
   mixins: [AccountsMixin],

--- a/src/components/profile/edit/EditContact.vue
+++ b/src/components/profile/edit/EditContact.vue
@@ -1,7 +1,6 @@
 <template>
   <EditMutationWrapper
     :editVariables="editVariables"
-    :initialValues="initialValues"
     :novalidate="true"
     formName="Edit contact information"
   >
@@ -189,7 +188,6 @@ export default {
     initialSecondaryEmail2: Object,
     initialPhoneNumbers: Object,
     initialUris: Object,
-    initialValues: Object,
   },
   mixins: [PhoneNumbersMixin, LinksMixin],
   components: {

--- a/src/components/profile/edit/EditIdentities.vue
+++ b/src/components/profile/edit/EditIdentities.vue
@@ -6,7 +6,6 @@
         bugzilla: bugzillaIdentityUpdate,
       },
     }"
-    :initialValues="{}"
     formName="Edit identities"
   >
     <header class="profile__section-header" ref="header" tabindex="-1">

--- a/src/components/profile/edit/EditLanguages.vue
+++ b/src/components/profile/edit/EditLanguages.vue
@@ -3,7 +3,6 @@
     :editVariables="{
       languages,
     }"
-    :initialValues="initialValues"
     formName="Edit languages"
     class="add-languages"
   >
@@ -63,7 +62,6 @@ import EditMutationWrapper from './EditMutationWrapper.vue';
 export default {
   name: 'EditLanguages',
   props: {
-    initialValues: Object,
     editVariables: Object,
     initialLanguages: {
       type: Object,

--- a/src/components/profile/edit/EditMutationWrapper.vue
+++ b/src/components/profile/edit/EditMutationWrapper.vue
@@ -49,7 +49,6 @@ export default {
     LoadingSpinner,
   },
   props: {
-    initialValues: Object,
     formName: String,
     editVariables: Object,
     novalidate: {

--- a/src/components/profile/edit/EditPersonalInfo.vue
+++ b/src/components/profile/edit/EditPersonalInfo.vue
@@ -15,7 +15,6 @@
       staffInformationOfficeLocationDisplay:
         staffInformationOfficeLocation.display,
     }"
-    :initialValues="initialValues"
     formName="Edit personal information"
   >
     <EditPictureModal

--- a/src/components/profile/edit/EditTags.vue
+++ b/src/components/profile/edit/EditTags.vue
@@ -3,7 +3,6 @@
     :editVariables="{
       tags,
     }"
-    :initialValues="initialValues"
     formName="Edit tags"
     class="add-tags"
   >
@@ -63,7 +62,6 @@ import EditMutationWrapper from './EditMutationWrapper.vue';
 export default {
   name: 'EditTags',
   props: {
-    initialValues: Object,
     editVariables: Object,
     initialTags: {
       type: Object,

--- a/src/pages/PageOrgchart.vue
+++ b/src/pages/PageOrgchart.vue
@@ -40,7 +40,7 @@
         :variables="{ username }"
         :tag="null"
       >
-        <template slot-scope="{ result: { loading, data } }">
+        <template slot-scope="{ result: { data } }">
           <div class="org-chart__preview">
             <ProfilePreview
               v-if="data && desktopView"

--- a/src/pages/PageProfile.vue
+++ b/src/pages/PageProfile.vue
@@ -4,6 +4,7 @@
     :variables="variables"
     :fetchPolicy="viewAs.filter ? 'no-cache' : 'cache-first'"
     clientId="mutationClient"
+    :notifyOnNetworkStatusChange="true"
   >
     <template slot-scope="{ result: { loading, data, error } }">
       <LoadingSpinner v-if="loading"></LoadingSpinner>


### PR DESCRIPTION
https://jira.mozilla.com/browse/IAM-381
https://github.com/mozilla-iam/dino-park-issues/issues/160

https://github.com/mozilla-iam/dino-park-front-end/commit/c559d1169d7131298a90b71b51f85330a2289374 was all that was needed to fix this, but I included the small bits of cleanup I did while identifying that simple fix.

I'm relatively sure this also means we can remove all the complexity added in https://github.com/mozilla-iam/dino-park-front-end/commit/4304d8fd28544275555400fbbfee26cf9141b057 and go back to https://github.com/mozilla-iam/dino-park-front-end/commit/59b8ad5e7d738dc696f8291ce55e60f918823ef0 to fix that issue.

