### PR TITLE
If the build does not succeed we do not want to deploy

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -19,6 +19,7 @@ phases:
       - if [ "$MASTER" = 1 ]; then myke docker --rev=$COMMIT_SHA push-image --rev=$COMMIT_SHA; fi
   post_build:
     commands:
+      - if [ "$CODEBUILD_BUILD_SUCCEEDING" = 0 ] ; then exit 1 ; fi
       - |
         if [ "$PR" = "" ] &&  { [ "$DEPLOY_ENV" = "dev" ] || [ "$DEPLOY_ENV" = "test" ] ;}; then
           echo "Deploying to dev and test envirnoments..."


### PR DESCRIPTION
AWS Codebuild executes the `post_build` block regardless the exit status of the `build` block [1]. 
With the current configuration, if a build fails, a new container won't be uploaded, however we will deploy a new manifest of the application to Kubernetes referencing the never-uplodaded container. This will make the new deployment hang (as it just happened today).
This change should address this situation. The variable "CODEBUILD_BUILD_SUCCEEDING" is set by Codebuild on success of the `build` block [2].

[1] https://docs.aws.amazon.com/codebuild/latest/userguide/view-build-details.html#view-build-details-phases
[2] https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html