### PR TITLE
don't use svg-sprite-loader outside of Icon.vue

### DIFF
--- a/src/components/ui/Select.vue
+++ b/src/components/ui/Select.vue
@@ -182,7 +182,7 @@ export default {
   }
 }
 .options--chevron .options__toggle {
-  background-image: url('../../assets/svg/chevron-down.svg');
+  background-image: url('~@/assets/svg/chevron-down.svg');
   background-repeat: no-repeat;
   background-position: center right 0.75em;
   background-size: 1.25em;
@@ -271,7 +271,7 @@ export default {
   padding: 1em 3em 1em 2em;
   color: var(--black);
   border-radius: 2.5em;
-  background-image: url('../../assets/svg/chevron-down.svg');
+  background-image: url('~@/assets/svg/chevron-down.svg');
   background-repeat: no-repeat;
   background-position: center right 1em;
   background-size: 1.25em;
@@ -280,19 +280,19 @@ export default {
   background-color: var(--blue-60);
   color: var(--white);
   border-color: transparent;
-  background-image: url('../../assets/images/chevron-down-white.svg');
+  background-image: url('~@/assets/images/chevron-down-white.svg');
 }
 .privacy-select--large .options__toggle:not([disabled]):hover {
   background-color: var(--black);
   color: var(--white);
   border-color: transparent;
-  background-image: url('../../assets/images/chevron-down-white.svg');
+  background-image: url('~@/assets/images/chevron-down-white.svg');
 }
 .privacy-select--blue .options__toggle:not([disabled]):hover {
   background-color: var(--white);
   border-color: var(--blue-60);
   color: var(--blue-60);
-  background-image: url('../../assets/images/chevron-down-blue-60.svg');
+  background-image: url('~@/assets/images/chevron-down-blue-60.svg');
 }
 .privacy-select--large .options__toggle svg {
   order: -1;

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,4 @@
 const fs = require('fs');
-const SpriteLoaderPlugin = require('svg-sprite-loader/plugin');
 
 const BASE_URL = process.env.DP_BASE_URL || '/';
 const HTTPS_KEY = process.env.DP_HTTPS_KEY || false;
@@ -16,7 +15,17 @@ module.exports = {
   publicPath: BASE_URL,
   chainWebpack: (config) => {
     const svgRule = config.module.rule('svg');
-    svgRule.uses.clear().end();
+    svgRule
+      .use('image-webpack-loader')
+      .loader('image-webpack-loader')
+      .tap((options) => {
+        return {
+          svgo: {
+            plugins: [],
+          },
+        };
+      })
+      .end();
   },
   configureWebpack: {
     resolve: {
@@ -35,32 +44,8 @@ module.exports = {
           test: /\.ftl$/,
           use: 'raw-loader',
         },
-        {
-          test: /\.svg$/,
-          include: /src\/assets\//,
-          use: [
-            {
-              loader: 'svg-sprite-loader',
-              options: {
-                extract: true,
-                esModule: false,
-                publicPath: '/img/',
-                spriteFilename: 'sprite.[hash:8].svg',
-              },
-            },
-            {
-              loader: 'image-webpack-loader',
-              options: {
-                svgo: {
-                  plugins: [],
-                },
-              },
-            },
-          ],
-        },
       ],
     },
-    plugins: [new SpriteLoaderPlugin()],
   },
   devServer: {
     https: HTTPS,


### PR DESCRIPTION
https://jira.mozilla.com/browse/IAM-230

svg-sprite-loader wasn't working with mini-css-extract-plugin, the
latter only being used in production builds, causing missing svgs
referenced in our css

the proposed solution is to use a different webpack plugin instead:
https://github.com/JetBrains/svg-sprite-loader/issues/271#issuecomment-425361287

we don't really need to use an svg sprite for the few places we use
svgs outside of the Icon.vue component