### PR TITLE
Remove leading and trailing space from displayed profile name

### DIFF
--- a/src/components/profile/ProfileName.vue
+++ b/src/components/profile/ProfileName.vue
@@ -1,11 +1,10 @@
 <template>
   <div class="profile__name">
-    <h1>
-      {{ firstName }} {{ lastName }}
-      <span class="profile__alternative-name" v-if="alternativeName">
-        {{ alternativeName }}</span
-      >
-    </h1>
+    <h1>{{ firstName }} {{ lastName }}<span
+        class="profile__alternative-name" v-if="alternativeName"
+        >{{ alternativeName }}</span
+      ></h1
+    >
     <span class="profile__user-name" v-if="prettierUsername"
       >@{{ prettierUsername }}</span
     >


### PR DESCRIPTION
This way when selecting a profile name to copy paste it doesn't contain a leading and trailing space.