### PR TITLE
Fix group display name that was broken in #639

### DIFF
--- a/src/components/access_group/AccessGroupDescription.vue
+++ b/src/components/access_group/AccessGroupDescription.vue
@@ -31,8 +31,7 @@
         ></EditButton>
       </div>
       <h1 class="description-container__title"
-        >{{ groupInformation.group.name }}<
-      /h1>
+        >{{ groupInformation.group.name }}</h1>
     </header>
     <section v-if="groupInformation.membership.role" class="membership">
       <dl>


### PR DESCRIPTION
I broke this in #639