### PR TITLE
feature(onboarding): Add error messaging 

### DIFF
--- a/src/assets/js/scope.js
+++ b/src/assets/js/scope.js
@@ -24,7 +24,7 @@ class Scope {
     this.isLoggedIn = Boolean(username || user?.loggedIn);
     this.firstTime =
       this.isLoggedIn && (username === '' || username.startsWith('r--'));
-    this.isReady = Boolean(username);
+    this.isReady = Boolean(username || user?.profileError);
     this.isStaff = isStaff;
     this.isNdaed =
       'nda' in (mozilliansorgGroups || {}) ||
@@ -34,6 +34,7 @@ class Scope {
     this.isGroupCreator =
       'group_creators' in (mozilliansorgGroups || {}) ||
       'group_admins' in (mozilliansorgGroups || {});
+    this.profileError = user?.profileError
   }
 
   hasTrust(trust) {

--- a/src/components/guide/OnboardingModal.vue
+++ b/src/components/guide/OnboardingModal.vue
@@ -28,7 +28,26 @@
         <p v-else>
           <Fluent :id="`onboarding_modal_username`" attr="paragraph_2" />
         </p>
-        <section v-if="scope.isReady" class="onboarding-modal__username">
+        <section v-if="scope.profileError" class="onboarding-modal__profile_error">
+        <p> 
+          <Fluent :id="`onboarding_modal_profile_error`"
+                  attr="profile_error" 
+                  :tags="{
+                    iam_slack: {
+                      tag: 'a',
+                      target: '_blank',
+                      href: 'https://mozilla.slack.com/archives/CBT3XRZKP',
+                    },
+                    support_email: {
+                      tag: 'a',
+                      target: '_blank',
+                      href: 'mailto:people-mozilla-org-support@mozilla.com',
+                    }
+                  }"
+          /> 
+        </p>
+        </section>
+        <section v-if="scope.isReady && !scope.profileError" class="onboarding-modal__username">
           <label for="field-username">{{ fluent('profile_username') }}</label>
           <TextInput
             class="username__input"
@@ -336,5 +355,10 @@ export default {
   display: flex;
   align-items: center;
   flex-direction: row;
+}
+
+.onboarding-modal__profile_error {
+  font-weight: bold;
+  color: red;
 }
 </style>

--- a/src/locales/en-US/strings.ftl
+++ b/src/locales/en-US/strings.ftl
@@ -109,7 +109,7 @@ onboarding_modal_username = Getting started
   .username_chars = Username must only contain latin characters a-z or digits 0-9
 
 onboarding_modal_profile_error =
-  .profile_error = Error in creating profile please reach out in <a data-l10n-name="iam_slack">#iam</a> Slack or at <a data-l10n-name="support_email">people-mozilla-org-support@mozilla.com</a>
+  .profile_error = Error in creating profile. Please reach out in <a data-l10n-name="iam_slack">#iam</a> Slack or at <a data-l10n-name="support_email">people-mozilla-org-support@mozilla.com</a>
 
 tooltip_tour = Welcome
   .skip = Skip tour

--- a/src/locales/en-US/strings.ftl
+++ b/src/locales/en-US/strings.ftl
@@ -108,6 +108,9 @@ onboarding_modal_username = Getting started
   .username_space = Username must not contain spaces
   .username_chars = Username must only contain latin characters a-z or digits 0-9
 
+onboarding_modal_profile_error =
+  .profile_error = Error in creating profile please reach out in <a data-l10n-name="iam_slack">#iam</a> Slack or at <a data-l10n-name="support_email">people-mozilla-org-support@mozilla.com</a>
+
 tooltip_tour = Welcome
   .skip = Skip tour
   .step1_1 = Find Mozillians (staff and volunteers) based on their chosen visibility settings.

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -9,6 +9,7 @@ import scope from './scope.store';
 import features from './features.store';
 
 let shouldFetch = true;
+let userFound = false;
 
 async function fetchUser(commit) {
   if (shouldFetch === false){
@@ -21,6 +22,7 @@ async function fetchUser(commit) {
       variables: { username: null },
       fetchPolicy,
     });
+    userFound = true;
     commit('setUser', data.profile);
     return true;
   } catch (e) {
@@ -45,6 +47,8 @@ async function fetchUser(commit) {
 async function retryFetchUser(commit, retries = 120) {
   if (!(await fetchUser(commit)) && retries > 0) {
     setTimeout(() => retryFetchUser(commit, retries - 1), 1000);
+  } else if (!userFound) {
+    commit('setUser', {profileError: true});
   }
 }
 
@@ -64,7 +68,6 @@ export default new Vuex.Store({
     onboarding: new Onboarding(),
   },
   actions: {
-    // TODO: Create error handling for this action
     async fetchUser({ commit }) {
       await retryFetchUser(commit);
     },


### PR DESCRIPTION
Currently if a user has a profile in the CIS database but is not set to active we will continuously query CIS, eventually giving up but not showing any error to the user. This updates the frontend to show an error to the user and where they can go for help.

![Screenshot 2022-05-09 at 14-02-11 Mozilla People Directory](https://user-images.githubusercontent.com/1072933/167479393-d2606163-73ab-491a-be67-38726110df39.png)

