### PR TITLE
Make search input `autofocus`

### DIFF
--- a/src/components/ui/SearchForm.vue
+++ b/src/components/ui/SearchForm.vue
@@ -14,6 +14,7 @@
         <!-- TODO: fix placeholder fluent. search 'searchFormLabel' and replace with fluent in all code -->
         <input
           type="text"
+          autofocus=""
           id="search-query"
           name="query"
           v-model="searchQuery"


### PR DESCRIPTION
This will definitely require testing. I'm especially curious devices with reduced screen resolution or vertical screen layouts (e.g., mobile) because the responsive layout seems to hide most of the input element there. Maybe this will work with the styles, but I honestly haven't tested this.

Is it acceptable to test on a staging/prod environment or would you prefer I set some time aside in the coming weeks and try a local build? (I've never build this project, I admit that this is a bit of a reckless pull request and am OK with this not being really doable after all).

Thanks!