### PR TITLE
apply the view costCenter filter to edit

### DIFF
--- a/src/components/profile/edit/EditPersonalInfo.vue
+++ b/src/components/profile/edit/EditPersonalInfo.vue
@@ -354,7 +354,10 @@
           type="text"
           id="field-cost-center"
           disabled
-          :value="staffInformation.costCenter.value"
+          :value="
+            staffInformation.costCenter.value &&
+            staffInformation.costCenter.value.replace(/\.0$/, '')
+          "
         />
         <PrivacySetting
           :label="fluent('profile_cost-center', 'privacy')"


### PR DESCRIPTION
Something in the CIS pipeline is appending ".0" to cost centers, which is then displayed to user _only_ when editing their profiles, not when viewing those of others.

This patch applies the logic from the view page to the (readonly) field on the edit page as well, so that we're internally consistent within Dinopark and also consistent with the current 2023-era cost centers as shown in Finance documents.

We still need to find what's injecting .0 and fix that, but this removes the user-visible impact for Dinopark until we do so, and will noop once that's removed upstream.