### PR TITLE
Revive the build for this project

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -16,8 +16,6 @@ phases:
       - export MASTER=$(if [ "$CODEBUILD_WEBHOOK_TRIGGER" = "branch/master" ]; then echo 1; fi)
       - echo "running for ${COMMIT_SHA} in ${DEPLOY_ENV}"
       - aws ecr get-login --region us-west-2 --no-include-email | bash
-      - echo "Logging Into Docker Hub"
-      - echo $DOCKERHUB_PASSWORD | docker login --username $DOCKERHUB_USERNAME --password-stdin
   build:
     commands:
       - if [ "$PR" = 1 ]; then myke docker; fi

--- a/terraform/codebuild/.terraform.lock.hcl
+++ b/terraform/codebuild/.terraform.lock.hcl
@@ -1,0 +1,28 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.10.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:3+TkVoKllN+U48xMQjZCB692MigTQCLkEfug6aYMG/c=",
+    "h1:ToB7wJhFPmcX1/0vbx5NgZAnP+cJ7Rti5NpNPyEJpxI=",
+    "h1:Ukz833hY+KoxjTmaTeVO2R0ZUM8VQnGBQP8HWl3Ws7Q=",
+    "h1:X3awQfl6nyOedeuQ0yHUW7Az7JEzH5TIn1cOgJbIvaQ=",
+    "zh:3c92efebaf635372bf7283e04fc667d59b0ff3cf1aacd011fc484a11f70954d9",
+    "zh:404b2a1d360851e63f25945406f2d0c2cb9c20b361552ce01bf7fe3df516a5bf",
+    "zh:523b1640e2b9e2b548876a1dccc627c290f342255d727568fe4becfd9a8f5689",
+    "zh:697adf10c76384195303650555229129d64135f5be3abf95da0bf4b6de742054",
+    "zh:69d6177e3e106518844373871d4e6377003336761aab884da32f66b034229b5c",
+    "zh:6a41899ce8ab9cdd6f706160fd350951e5f3fc1432a37e638d3576a780c686fd",
+    "zh:6e8fd28299d6bf0ab6922cf987757e578f357a45ac45abc312688580dbde3bee",
+    "zh:7ca4bfb5a8f89586dd0c8dd9c1e638a03bc7c6f456bcc29be57cfb7bdc90fc30",
+    "zh:8fe1f6e0a2718318bae3f53a4fb77bc9eaef0fc4131145996f48482b135830c6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b221cfbc9f19ad30719b773f05f45571e88b124c15c35ac230021df1bb1110f5",
+    "zh:b458c357b5f38092e374957e51827d9113447696deccf0cb01f5684d976e7725",
+    "zh:b7fbb1b05972d73d72af58a2179ac124c6d69a4f0392aa2ce4dc855e78f52268",
+    "zh:d95da0dc45df0f30005e17c5206addbd62b0471c265d9855fe8039bf6f2adef7",
+    "zh:db5dd4120c6ab6ae13df67353a9bc902ac34d01c1d297812d628ebf61dc6f681",
+  ]
+}

--- a/terraform/codebuild/main.tf
+++ b/terraform/codebuild/main.tf
@@ -29,18 +29,6 @@ resource "aws_codebuild_project" "build" {
       name  = "DOCKER_REPO"
       value = aws_ecr_repository.registry.repository_url
     }
-
-    environment_variable {
-      name  = "DOCKERHUB_USERNAME"
-      type  = "SECRETS_MANAGER"
-      value = "/CodeBuild/dockerhub:username"
-    }
-
-    environment_variable {
-      name  = "DOCKERHUB_PASSWORD"
-      type  = "SECRETS_MANAGER"
-      value = "/CodeBuild/dockerhub:password"
-    }
   }
 
   source {

--- a/terraform/codebuild/main.tf
+++ b/terraform/codebuild/main.tf
@@ -43,22 +43,6 @@ resource "aws_codebuild_project" "build" {
   }
 }
 
-# Unomment this section if you do want to build automatically on push
-resource "aws_codebuild_webhook" "webhook" {
-  project_name = aws_codebuild_project.build.name
-  filter_group {
-    filter {
-      type    = "EVENT"
-      pattern = "PUSH"
-    }
-
-    filter {
-      type    = "HEAD_REF"
-      pattern = "(^refs/heads/master$|^refs/tags/.*-(prod|test))"
-    }
-  }
-}
-
 #---
 # IAM configuration
 #---

--- a/terraform/codebuild/provider.tf
+++ b/terraform/codebuild/provider.tf
@@ -7,12 +7,17 @@ provider "aws" {
 }
 
 terraform {
-  required_version = "~> 0.12"
-
+  required_version = ">= 1.5.0"
   backend "s3" {
     bucket = "eks-terraform-shared-state"
     key    = "global/codebuild/dino-park-front-end/terraform.tfstate"
     region = "us-west-2"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
   }
 }
 

--- a/terraform/codebuild/variables.tf
+++ b/terraform/codebuild/variables.tf
@@ -4,7 +4,7 @@ variable "project_name" {
 }
 
 variable "github_repo" {
-  default = "https://github.com/mozilla-iam/dino-park-front-end"
+  default = "https://github.com/mozilla-iam/dino-park-front-end.git"
 }
 
 variable "buildspec_file" {


### PR DESCRIPTION
There's a couple have things that have changed since the last time we deployed.

1. We don't use Docker Hub. We _could_ keep this integration around, but then we'd need to
   decide which set of credentials to use (we have two sets). I don't see us running into the public
   rate limit, so this isn't a huge concern.
2. Webhooks have never been fired, for some reason. See attached screenshot. I'm disabling this for now.
3. Terraform published new versions. So, we're now on a much more recent version.

<img width="1053" height="418" alt="Screenshot 2025-08-26 at 12 51 40" src="https://github.com/user-attachments/assets/b1e9c2ed-f9ba-48e3-8e41-a89e12579ee2" />

A successful run, for deploying to dev and stage: [CodeBuild](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/320464205386/projects/dino-park-front-end/build/dino-park-front-end%3A342a40d1-9c2a-4e12-a3b6-7c7858b89c7a/?region=us-west-2).

Jira: [IAM-1751](https://mozilla-hub.atlassian.net/browse/IAM-1751)
